### PR TITLE
py-jltheme: clean up and remove redundant/faulty hook

### DIFF
--- a/packages/py-jltheme/package.py
+++ b/packages/py-jltheme/package.py
@@ -19,11 +19,3 @@ Adjusts Matplotlib axis labels, edge, face, and tick colors based upon which Jup
     version('0.1.2', sha256='75361cbd59c835d7d71b8c9c23dd9ddf4644bf67d7e2a42afa260de7c39aa028')
 
     depends_on('py-jupyter', type=('run'))
-
-    @run_before('build')
-    def ensure_readme_rst(self):
-        with working_dir(self.stage.source_path):
-            if not os.path.exists("README.rst"):
-                f = open("README.rst","w")
-                f.write("description")
-                f.close()

--- a/packages/py-jltheme/package.py
+++ b/packages/py-jltheme/package.py
@@ -3,13 +3,16 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 import os
+from spack.package import *
+
 
 class PyJltheme(PythonPackage):
-    """FIXME: Put a proper description of your package here."""
+    """Change Matplotlib rcParams to match the current JupyterLab theme.
 
-    # FIXME: Add a proper url for your package's homepage here.
+Adjusts Matplotlib axis labels, edge, face, and tick colors based upon which JupyterLab theme is in use.
+"""
+
     homepage = "https://github.com/CGCFAD/jltheme"
     pypi     = "jltheme/jltheme-0.1.2.tar.gz"
 
@@ -24,9 +27,3 @@ class PyJltheme(PythonPackage):
                 f = open("README.rst","w")
                 f.write("description")
                 f.close()
-
-    def build_args(self, spec, prefix):
-        # FIXME: Add arguments other than --prefix
-        # FIXME: If not needed delete this function
-        args = []
-        return args


### PR DESCRIPTION
- py-jltheme: Basic cleanup
- py-jltheme: remove redundant/faulty hook ensure_readme_rst()
