### PR TITLE
Update s124 to correspond to actual package versions. Comment out py-…

### DIFF
--- a/packages/art-suite/package.py
+++ b/packages/art-suite/package.py
@@ -25,37 +25,37 @@ class ArtSuite(BundlePackage):
     variant("root", default=True, description="Also bring in the ROOT IO packages")
     
     with when("@s124"):
-        depends_on("cmake@3.26.4")
+        depends_on("cmake@3.26.3")
 
-        depends_on("art@3.13.02 cxxstd=20")
-        depends_on("art-root-io@1.12.03 cxxstd=20", when="+root")
-        depends_on("boost@1.81.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals+system+test+thread+timer+wave cxxstd=20") # Sum of all needed libraries...
-        depends_on("canvas@3.15.01 cxxstd=20")
-        depends_on("canvas-root-io@1.12.02 cxxstd=20", when="+root")
-        depends_on("catch2@3.0.1") # 3.3.1 not published to Spack
-        depends_on("cetlib@3.17.00 cxxstd=20")
-        depends_on("cetlib-except@1.09.00 cxxstd=20")
+        depends_on("art@3.13.02 cxxstd=17")
+        depends_on("art-root-io@1.12.04 cxxstd=17", when="+root")
+        depends_on("boost@1.82.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
+        depends_on("canvas@3.15.02 cxxstd=17")
+        depends_on("canvas-root-io@1.12.03 cxxstd=17", when="+root")
+        depends_on("catch2@3.3.2") 
+        depends_on("cetlib@3.17.01 cxxstd=17")
+        depends_on("cetlib-except@1.09.01 cxxstd=17")
         depends_on("cetmodules@3.21.02")
-        depends_on("clhep@2.4.6.4 cxxstd=20")
+        depends_on("clhep@2.4.6.4 cxxstd=17")
         depends_on("fftw@3.3.10")
-        depends_on("fhicl-cpp@4.18.00 cxxstd=20")
+        depends_on("fhicl-cpp@4.18.01 cxxstd=17")
         depends_on("gsl@2.7")
-        depends_on("hep-concurrency@1.09.00 cxxstd=20")
+        depends_on("hep-concurrency@1.09.01 cxxstd=17")
         depends_on("libxml2@2.9.12")
-        depends_on("messagefacility@2.10.01 cxxstd=20")
-        depends_on("py-numpy@1.24.1")
-        depends_on("openblas@0.3.21")
-        depends_on("postgresql@15.2") # 15.1 not published to spack
+        depends_on("messagefacility@2.10.02 cxxstd=17")
+        depends_on("py-numpy@1.24.3")
+        depends_on("openblas@0.3.23")
+        depends_on("postgresql@15.2") # 15.3 not published to spack
         depends_on("py-pybind11@2.10.1") # 2.10.3 not published to spack
         depends_on("pythia6@6.4.28")
         depends_on("python@3.9.15")
-        depends_on("range-v3@master cxxstd=20") # 0.12.0 not published to Spack
-        depends_on("root@6.28.00 cxxstd=20", when="+root")
+        depends_on("range-v3@master cxxstd=17") # 0.12.0 not published to Spack
+        depends_on("root@6.28.04 cxxstd=17", when="+root")
         depends_on("sqlite@3.40.1")
-        depends_on("tbb@2021.8.0 cxxstd=20")
-        depends_on("xrootd@5.5.3 cxxstd=20")
+        depends_on("tbb@2021.9.0 cxxstd=17")
+        depends_on("xrootd@5.5.5 cxxstd=17")
     with when("@s123"):
-        depends_on("cmake@3.26.4")
+        depends_on("cmake@3.26.3")
 
         depends_on("art@3.13.01 cxxstd=17")
         depends_on("art-root-io@1.12.03 cxxstd=17", when="+root")

--- a/packages/cetmodules/package.py
+++ b/packages/cetmodules/package.py
@@ -15,7 +15,7 @@ class Cetmodules(CMakePackage):
 
     homepage = "https://fnalssi.github.io/cetmodules/"
     git = "https://github.com/FNALssi/cetmodules.git"
-    url = "https://github.com/FNALssi/cetmodules/archive/refs/tags/3.21.01.tar.gz"
+    url = "https://github.com/FNALssi/cetmodules/archive/refs/tags/3.21.02.tar.gz"
 
     maintainers = ["chissg", "gartung", "marcmengel", "vitodb"]
 
@@ -23,6 +23,7 @@ class Cetmodules(CMakePackage):
     version("3.19.02", sha256="214172a59f4c3875a5d7c2617b9f50ed471c86404d85e2e5c72cadf5b499cdc6")
     version("3.21.00", sha256="429ddecf2e905a6a3156c267005d17cd6e160533f28bcef0be40a9d0057e95e4")
     version("3.21.01", sha256="9f4b845f9ed09fb3a8ee7864ac487afd08a5b3e64abf394831ee927f91b08ebc")
+    version("3.21.02", sha256="255d6d6c2455217734b208fc90919b90bc7c0f9a59a4706d329c642bff51f004")
 
     variant(
         "versioned-docs", default=False, description="build versioned docs with a landing page"
@@ -33,7 +34,7 @@ class Cetmodules(CMakePackage):
 
     docs_deps = (
         "git@2.22:",
-        "py-sphinxcontrib-moderncmakedomain",
+#        "py-sphinxcontrib-moderncmakedomain",
         "py-sphinx-design@0.2.0:",
         "py-sphinx@5:5.999",
     )


### PR DESCRIPTION
…sphinxcontrib-moderncmakedomain, as it does not seem to be a package anymore