### PR TITLE
Constrain OpenSSL version to less than 3

### DIFF
--- a/packages/cetlib/package.py
+++ b/packages/cetlib/package.py
@@ -41,7 +41,7 @@ class Cetlib(CMakePackage):
     depends_on("boost+regex+program_options+filesystem+system+test")
     depends_on("cetlib-except")
     depends_on("hep-concurrency")
-    depends_on("openssl")
+    depends_on("openssl@:2.99")
     depends_on("perl", type=("build", "run"))
     depends_on("sqlite@3.8.2:")
     depends_on("tbb")


### PR DESCRIPTION
`cetlib` uses MD5 API that has been deprecated for OpenSSL 3 and higher.