### PR TITLE
Disallow C++17 for art-suite@develop, etc.

### DIFF
--- a/lib/preset_args.py
+++ b/lib/preset_args.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def preset_args(source_path):
+    if (Path(source_path) / "CMakePresets.json").exists():
+        return ["--preset", "default"]
+    return []

--- a/packages/art-root-io/package.py
+++ b/packages/art-root-io/package.py
@@ -25,7 +25,7 @@ class ArtRootIo(CMakePackage):
     version("1.12.04", sha256="912e01cb3f253de244548a52ee4f9e31b2eb6d1af9bd7cb33e48bab064651273")
     version("1.12.03", sha256="2281435aa910085902f9a8d14c90d69ee980a980637bbb4bb2e1aad1ab5f02af")
     version("1.12.02", sha256="f7fa60cad2947fa135cdd52cb5d39d3e871cca246181288734745067c7c3f555")
-    version("1.12.01", sha256="d6594b039567c5f4a7053678d70b82e543a19fef989f0957ca6a6e4862372511") 
+    version("1.12.01", sha256="d6594b039567c5f4a7053678d70b82e543a19fef989f0957ca6a6e4862372511")
     version("1.11.03", sha256="a29b64b07709ac1560ccc1b9570cc8a4197a8834d2b9dfea5bbfd293231d4a20")
     version("1.11.00", sha256="1134d1c1e69045249bf678e6e07728f06035ee2ee982af5155184d1c271468ae")
     version("1.08.05", sha256="77f58e4200f699dcb324a3a9fc9e59562d2a1721a34a6db43fdb435853890d21")
@@ -40,6 +40,7 @@ class ArtRootIo(CMakePackage):
         sticky=True,
         description="C++ standard",
     )
+    conflicts("cxxstd=17", when="@develop")
 
     depends_on("art")
     depends_on("boost+filesystem+date_time+program_options")
@@ -66,11 +67,11 @@ class ArtRootIo(CMakePackage):
     def url_for_version(self, version):
         url = "https://github.com/art-framework-suite/art-root-io/archive/refs/tags/v{0}.tar.gz"
         return url.format(version.underscored)
-    
+
     def cmake_args(self):
         return [
            "--trace-expand",
-           "--preset", "default", 
+           "--preset", "default",
            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
         ]
 

--- a/packages/art-root-io/package.py
+++ b/packages/art-root-io/package.py
@@ -4,6 +4,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import sys
+
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parents[2] / "lib"))
+from preset_args import preset_args
 
 from spack.package import *
 
@@ -31,7 +37,6 @@ class ArtRootIo(CMakePackage):
     version("1.08.05", sha256="77f58e4200f699dcb324a3a9fc9e59562d2a1721a34a6db43fdb435853890d21")
     version("1.08.03", sha256="fefdb0803bc139a65339d9fa1509f2e9be1c5613b64ec1ec84e99f404663e4bf")
 
-
     variant(
         "cxxstd",
         default="17",
@@ -50,9 +55,9 @@ class ArtRootIo(CMakePackage):
     depends_on("catch2@2.3.0:", when="@:1.11.99", type=("build", "test"))
     depends_on("cetlib")
     depends_on("cetlib-except")
-    #depends_on("cetmodules@3.19.02:", type="build")
+    # depends_on("cetmodules@3.19.02:", type="build")
     depends_on("cetmodules", type="build")
-    #conflicts("cetmodules@:3.21.00", when="catch2@3:")
+    # conflicts("cetmodules@:3.21.00", when="catch2@3:")
     depends_on("fhicl-cpp")
     depends_on("hep-concurrency")
     depends_on("messagefacility")
@@ -69,10 +74,9 @@ class ArtRootIo(CMakePackage):
         return url.format(version.underscored)
 
     def cmake_args(self):
-        return [
-           "--trace-expand",
-           "--preset", "default",
-           self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+        return preset_args(self.stage.source_path) + [
+            "--trace-expand",
+            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
         ]
 
     def setup_build_environment(self, env):

--- a/packages/art/package.py
+++ b/packages/art/package.py
@@ -46,9 +46,10 @@ class Art(CMakePackage):
         sticky=True,
         description="C++ standard",
     )
+    conflicts("cxxstd=17", when="@develop")
 
     depends_on("boost+date_time+graph+program_options+regex")
-    depends_on("boost+filesystem+json+test+thread", type=("build"))
+    depends_on("boost+filesystem+json+test+thread cxxstd=11", type=("build"))
     depends_on("boost+graph+test", type=("test"))
     depends_on("canvas")
     depends_on("catch2@2.3.0", type=("build", "test"), when="@:3.11.99")
@@ -77,7 +78,7 @@ class Art(CMakePackage):
 
     def cmake_args(self):
         return [
-           "--preset", "default", 
+           "--preset", "default",
            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
         ]
 

--- a/packages/art/package.py
+++ b/packages/art/package.py
@@ -4,6 +4,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import sys
+
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parents[2] / "lib"))
+from preset_args import preset_args
 
 from spack import *
 
@@ -22,7 +28,6 @@ class Art(CMakePackage):
     homepage = "https://art.fnal.gov/"
     git = "https://github.com/art-framework-suite/art.git"
     url = "https://github.com/art-framework-suite/art/archive/refs/tags/v3_13_01.tar.gz"
-
 
     version("3.14.01", sha256="29489e0dc7abf2756c9081569a54dbb49c8cbb472c651e343d6ce2d49fc1cac2")
     version("3.14.00", sha256="20eaa43d68b07eb5ea87c10c2e1b85a91dc5eaa3b4b83841b67e76dd64399ef0")
@@ -77,9 +82,8 @@ class Art(CMakePackage):
         return url.format(version.underscored)
 
     def cmake_args(self):
-        return [
-           "--preset", "default",
-           self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+        return preset_args(self.stage.source_path) + [
+            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd")
         ]
 
     def setup_build_environment(self, env):

--- a/packages/canvas-root-io/package.py
+++ b/packages/canvas-root-io/package.py
@@ -39,6 +39,7 @@ class CanvasRootIo(CMakePackage):
         sticky=True,
         description="C++ standard",
     )
+    conflicts("cxxstd=17", when="@develop")
 
     depends_on("boost+thread")
     depends_on("canvas")
@@ -61,7 +62,7 @@ class CanvasRootIo(CMakePackage):
 
     def cmake_args(self):
         return [
-           "--preset", "default", 
+           "--preset", "default",
            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
         ]
 

--- a/packages/canvas-root-io/package.py
+++ b/packages/canvas-root-io/package.py
@@ -29,7 +29,7 @@ class CanvasRootIo(CMakePackage):
     version("1.11.00", sha256="950ccf0277f7315d396ae49f6421fd613a7bb34cf7cba68c1c2dfb062b990b6c")
     version("1.09.04", sha256="cb854b4fdc72be24856886d985f96ceb3b0049729df0b4a11fb501ff7c48847b")
 
-    patch("test_build.patch",when="@:1.11.00")
+    patch("test_build.patch", when="@:1.11.00")
 
     variant(
         "cxxstd",
@@ -61,9 +61,8 @@ class CanvasRootIo(CMakePackage):
             depends_on("ninja@1.10:", type="build")
 
     def cmake_args(self):
-        return [
-           "--preset", "default",
-           self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+        return preset_args(self.stage.source_path) + [
+            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd")
         ]
 
     def url_for_version(self, version):

--- a/packages/canvas/package.py
+++ b/packages/canvas/package.py
@@ -4,6 +4,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import sys
+
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parents[2] / "lib"))
+from preset_args import preset_args
 
 from spack.package import *
 
@@ -64,9 +70,8 @@ class Canvas(CMakePackage):
         return url.format(version.underscored)
 
     def cmake_args(self):
-        return [
-           "--preset", "default",
-           self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+        return preset_args(self.stage.source_path) + [
+            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd")
         ]
 
     def setup_build_environment(self, env):

--- a/packages/canvas/package.py
+++ b/packages/canvas/package.py
@@ -40,6 +40,7 @@ class Canvas(CMakePackage):
         sticky=True,
         description="C++ standard",
     )
+    conflicts("cxxstd=17", when="@develop")
 
     depends_on("boost+date_time+test")
     depends_on("cetlib")
@@ -64,7 +65,7 @@ class Canvas(CMakePackage):
 
     def cmake_args(self):
         return [
-           "--preset", "default", 
+           "--preset", "default",
            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
         ]
 

--- a/packages/cetlib-except/package.py
+++ b/packages/cetlib-except/package.py
@@ -4,6 +4,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import sys
+
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parents[2] / "lib"))
+from preset_args import preset_args
 
 from spack.package import *
 
@@ -52,9 +58,8 @@ class CetlibExcept(CMakePackage):
         return url.format(version.underscored)
 
     def cmake_args(self):
-        return [
-           "--preset", "default",
-           self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+        return preset_args(self.stage.source_path) + [
+            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd")
         ]
 
     def setup_build_environment(self, env):

--- a/packages/cetlib-except/package.py
+++ b/packages/cetlib-except/package.py
@@ -36,6 +36,7 @@ class CetlibExcept(CMakePackage):
         sticky=True,
         description="C++ standard",
     )
+    conflicts("cxxstd=17", when="@develop")
 
     depends_on("catch2@2.3.0:", type=("build", "test"))
     depends_on("cetmodules@3.19.02:", type="build")
@@ -52,7 +53,7 @@ class CetlibExcept(CMakePackage):
 
     def cmake_args(self):
         return [
-           "--preset", "default", 
+           "--preset", "default",
            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
         ]
 

--- a/packages/cetlib/package.py
+++ b/packages/cetlib/package.py
@@ -4,6 +4,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import sys
+
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parents[2] / "lib"))
+from preset_args import preset_args
 
 from spack.package import *
 
@@ -39,7 +45,7 @@ class Cetlib(CMakePackage):
     )
     conflicts("cxxstd=17", when="@develop")
 
-    patch("test_build.patch",when="@:3.16.00")
+    patch("test_build.patch", when="@:3.16.00")
 
     depends_on("boost+regex+program_options+filesystem+system+test")
     depends_on("cetlib-except")
@@ -64,9 +70,8 @@ class Cetlib(CMakePackage):
         return url.format(version.underscored)
 
     def cmake_args(self):
-        return [
-           "--preset", "default",
-           self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+        return preset_args(self.stage.source_path) + [
+            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd")
         ]
 
     def setup_build_environment(self, env):

--- a/packages/cetlib/package.py
+++ b/packages/cetlib/package.py
@@ -24,7 +24,7 @@ class Cetlib(CMakePackage):
     version("3.18.01", sha256="7e8b39e6ad0dce26d7fa41985d962fd2f97113403511bad0134c86ccee0e17ae")
     version("3.18.00", sha256="bf559b054af5881ef9e1b7ef91bb722fd255e178edbeca204d201584ee277fee")
     version("3.17.01", sha256="c29add5c9085e1fadc8f5fbdb1cd9b666d2290bd252022cef1feb0c30368d597")
-    version("3.17.00", sha256="04160b9607948b329465b60271ca735c449f3bf7d53e31a44ec3107cc6aafe26")    
+    version("3.17.00", sha256="04160b9607948b329465b60271ca735c449f3bf7d53e31a44ec3107cc6aafe26")
     version("3.16.00", sha256="a0e670a5144b215c9a6641d0b9b35512790d9ba4b638e213651f5040417f4070")
     version("3.13.04", sha256="40ca829cfb172f6cbf516bd3427fc7b7e893f9c916d969800261194610c45edf")
     version("develop", branch="develop", get_full_repo=True)
@@ -37,6 +37,7 @@ class Cetlib(CMakePackage):
         sticky=True,
         description="C++ standard",
     )
+    conflicts("cxxstd=17", when="@develop")
 
     patch("test_build.patch",when="@:3.16.00")
 
@@ -64,7 +65,7 @@ class Cetlib(CMakePackage):
 
     def cmake_args(self):
         return [
-           "--preset", "default", 
+           "--preset", "default",
            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
         ]
 

--- a/packages/critic/package.py
+++ b/packages/critic/package.py
@@ -53,6 +53,7 @@ class Critic(CMakePackage):
         sticky=True,
         description="C++ standard",
     )
+    conflicts("cxxstd=17", when="@develop")
 
     depends_on("art")
     depends_on("art-root-io")
@@ -78,7 +79,7 @@ class Critic(CMakePackage):
 
     def cmake_args(self):
         return [
-           "--preset", "default", 
+           "--preset", "default",
            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
         ]
 

--- a/packages/critic/package.py
+++ b/packages/critic/package.py
@@ -4,6 +4,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import sys
+
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parents[2] / "lib"))
+from preset_args import preset_args
 
 import llnl.util.tty as tty
 
@@ -78,9 +84,8 @@ class Critic(CMakePackage):
         return url.format(version.underscored)
 
     def cmake_args(self):
-        return [
-           "--preset", "default",
-           self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+        return preset_args(self.stage.source_path) + [
+            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd")
         ]
 
     def setup_build_environment(self, env):

--- a/packages/fhicl-cpp/package.py
+++ b/packages/fhicl-cpp/package.py
@@ -38,6 +38,7 @@ class FhiclCpp(CMakePackage):
         sticky=True,
         description="C++ standard",
     )
+    conflicts("cxxstd=17", when="@develop")
 
     depends_on("boost+program_options+test")
     depends_on("cetlib")
@@ -64,7 +65,7 @@ class FhiclCpp(CMakePackage):
 
     def cmake_args(self):
         return [
-           "--preset", "default", 
+           "--preset", "default",
            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
         ]
 
@@ -74,3 +75,10 @@ class FhiclCpp(CMakePackage):
         env.prepend_path("PATH", os.path.join(prefix, "bin"))
         # Cleanup
         sanitize_environments(env, "PATH")
+
+    def setup_run_environment(self, env):
+        bindir = self.prefix.bin
+        # Bash completions.
+        env.from_sourcing_file(os.path.join(bindir, "fhicl-dump_completions"))
+        env.from_sourcing_file(os.path.join(bindir, "fhicl-expand_completions"))
+        env.from_sourcing_file(os.path.join(bindir, "fhicl-get_completions"))

--- a/packages/fhicl-cpp/package.py
+++ b/packages/fhicl-cpp/package.py
@@ -4,6 +4,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import sys
+
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parents[2] / "lib"))
+from preset_args import preset_args
 
 from spack.package import *
 
@@ -52,7 +58,7 @@ class FhiclCpp(CMakePackage):
     depends_on("sqlite")
     depends_on("tbb")
 
-    patch("test_build.patch",when="@:4.17.00")
+    patch("test_build.patch", when="@:4.17.00")
 
     if "SPACK_CMAKE_GENERATOR" in os.environ:
         generator = os.environ["SPACK_CMAKE_GENERATOR"]
@@ -64,9 +70,8 @@ class FhiclCpp(CMakePackage):
         return url.format(version.underscored)
 
     def cmake_args(self):
-        return [
-           "--preset", "default",
-           self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+        return preset_args(self.stage.source_path) + [
+            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd")
         ]
 
     def setup_build_environment(self, env):

--- a/packages/gallery/package.py
+++ b/packages/gallery/package.py
@@ -39,6 +39,7 @@ class Gallery(CMakePackage):
         sticky=True,
         description="C++ standard",
     )
+    conflicts("cxxstd=17", when="@develop")
 
     depends_on("canvas")
     depends_on("canvas-root-io")
@@ -59,7 +60,7 @@ class Gallery(CMakePackage):
 
     def cmake_args(self):
         return [
-           "--preset", "default", 
+           "--preset", "default",
            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
         ]
 

--- a/packages/gallery/package.py
+++ b/packages/gallery/package.py
@@ -4,6 +4,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import sys
+
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parents[2] / "lib"))
+from preset_args import preset_args
 
 from spack.package import *
 
@@ -23,13 +29,11 @@ class Gallery(CMakePackage):
     git = "https://github.com/art-framework-suite/gallery.git"
     url = "https://github.com/art-framework-suite/gallery/archive/refs/tags/v1_21_01.tar.gz"
 
-
     version("develop", branch="develop", get_full_repo=True)
     version("1.21.01", sha256="e932c2469de4abb87527defe7357ea6423e8dbc18ef9d9b5148e5e658c3ffc91")
     version("1.21.02", sha256="0eb3eff1a173d09b698e1ba174ab61d9af72937067b300f1b73d0eca73349294")
     version("1.21.03", sha256="b1f41e1e4efcaf73b6c90c12dc513217ea5591ce369a9335d2ca6f4d0f2b1728")
     version("1.20.02", sha256="433e2b5727b9d9cf47206d9a01db5eab27c5cbb76407bb0ec14c0fd4e4dc41f9")
-
 
     variant(
         "cxxstd",
@@ -59,9 +63,8 @@ class Gallery(CMakePackage):
         return url.format(version.underscored)
 
     def cmake_args(self):
-        return [
-           "--preset", "default",
-           self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+        return preset_args(self.stage.source_path) + [
+            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd")
         ]
 
     def setup_dependent_build_environment(self, env, dependent_spec):

--- a/packages/hep-concurrency/package.py
+++ b/packages/hep-concurrency/package.py
@@ -4,6 +4,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import sys
+
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parents[2] / "lib"))
+from preset_args import preset_args
 
 from spack.package import *
 
@@ -39,7 +45,7 @@ class HepConcurrency(CMakePackage):
     )
     conflicts("cxxstd=17", when="@develop")
 
-    depends_on("catch2@3:",    when="@1.09.00:", type=("build", "test"))
+    depends_on("catch2@3:", when="@1.09.00:", type=("build", "test"))
     depends_on("catch2@2.3.0", when="@:1.08.99", type=("build", "test"))
     depends_on("cetlib-except")
     depends_on("cetmodules@3.19.02:", type="build")
@@ -54,13 +60,14 @@ class HepConcurrency(CMakePackage):
             depends_on("ninja@1.10:", type="build")
 
     def url_for_version(self, version):
-        url = "https://github.com/art-framework-suite/hep-concurrency/archive/refs/tags/v{0}.tar.gz"
+        url = (
+            "https://github.com/art-framework-suite/hep-concurrency/archive/refs/tags/v{0}.tar.gz"
+        )
         return url.format(version.underscored)
 
     def cmake_args(self):
-        return [
-           "--preset", "default",
-           self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+        return preset_args(self.stage.source_path) + [
+            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd")
         ]
 
     def setup_build_environment(self, env):

--- a/packages/hep-concurrency/package.py
+++ b/packages/hep-concurrency/package.py
@@ -37,6 +37,7 @@ class HepConcurrency(CMakePackage):
         sticky=True,
         description="C++ standard",
     )
+    conflicts("cxxstd=17", when="@develop")
 
     depends_on("catch2@3:",    when="@1.09.00:", type=("build", "test"))
     depends_on("catch2@2.3.0", when="@:1.08.99", type=("build", "test"))
@@ -58,7 +59,7 @@ class HepConcurrency(CMakePackage):
 
     def cmake_args(self):
         return [
-           "--preset", "default", 
+           "--preset", "default",
            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
         ]
 

--- a/packages/messagefacility/package.py
+++ b/packages/messagefacility/package.py
@@ -5,6 +5,12 @@
 
 
 import os
+import sys
+
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parents[2] / "lib"))
+from preset_args import preset_args
 
 from spack.package import *
 
@@ -61,13 +67,14 @@ class Messagefacility(CMakePackage):
             depends_on("ninja@1.10:", type="build")
 
     def url_for_version(self, version):
-        url = "https://github.com/art-framework-suite/messagefacility/archive/refs/tags/v{0}.tar.gz"
+        url = (
+            "https://github.com/art-framework-suite/messagefacility/archive/refs/tags/v{0}.tar.gz"
+        )
         return url.format(version.underscored)
 
     def cmake_args(self):
-        return [
-           "--preset", "default",
-           self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+        return preset_args(self.stage.source_path) + [
+            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd")
         ]
 
     def setup_build_environment(self, env):

--- a/packages/messagefacility/package.py
+++ b/packages/messagefacility/package.py
@@ -42,6 +42,7 @@ class Messagefacility(CMakePackage):
         sticky=True,
         description="C++ standard",
     )
+    conflicts("cxxstd=17", when="@develop")
 
     depends_on("boost+filesystem+program_options+system")
     depends_on("catch2")
@@ -65,7 +66,7 @@ class Messagefacility(CMakePackage):
 
     def cmake_args(self):
         return [
-           "--preset", "default", 
+           "--preset", "default",
            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
         ]
 


### PR DESCRIPTION
Includes:

- Forbidding C++17 when installing `@develop` (only C++20 and above is supported)
- Constraining Boost to `cxxstd=11` when using Boost JSON (otherwise it won't build/install)
- Miscellaneous whitespace cleanups