### PR TITLE
Adjust LArSoft recipes to support development

### DIFF
--- a/packages/larana/package.py
+++ b/packages/larana/package.py
@@ -29,7 +29,7 @@ class Larana(CMakePackage):
     """Larana"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/larana"
-    git_base = "https://github.com/LArSoft/larana.git"
+    git = "https://github.com/LArSoft/larana.git"
     url = "https://github.com/LArSoft/larana/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/larana/tags"
 
@@ -51,6 +51,7 @@ class Larana(CMakePackage):
     version("09.02.15", sha256="95653ea8022539bf367da7938f9e9d284ce2791f80a31ba578bfdf5b5c74a75d")
     version("09.02.14", sha256="0aafe08d52d360d648e1d63905384103cfb3d167b632f3b469ad355312209f47")
     version("mwm1", tag="mwm1", git="https://github.com/marcmengel/larana.git", get_full_repo=True)
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"

--- a/packages/larcore/package.py
+++ b/packages/larcore/package.py
@@ -29,7 +29,7 @@ class Larcore(CMakePackage):
     """Larcore"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/larcore"
-    git_base = "https://github.com/LArSoft/larcore.git"
+    git = "https://github.com/LArSoft/larcore.git"
     url = "https://github.com/LArSoft/larcore/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/larcore/tags"
     version("09.10.01", sha256="748ce3a30f81f2dc789be8d276fb0831c951eeef514ff4cae6e2d6ff291fb9fb")
@@ -55,6 +55,7 @@ class Larcore(CMakePackage):
     version(
         "mwm1", tag="mwm1", git="https://github.com/marcmengel/larcore.git", get_full_repo=True
     )
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"

--- a/packages/larcorealg/package.py
+++ b/packages/larcorealg/package.py
@@ -29,7 +29,7 @@ class Larcorealg(CMakePackage):
     """Larcorealg"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/larcorealg"
-    git_base = "https://github.com/LArSoft/larcorealg.git"
+    git = "https://github.com/LArSoft/larcorealg.git"
     url = "https://github.com/LArSoft/larcorealg/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/larcorealg/tags"
 
@@ -62,6 +62,7 @@ class Larcorealg(CMakePackage):
     version(
         "mwm1", tag="mwm1", git="https://github.com/marcmengel/larcorealg.git", get_full_repo=True
     )
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"

--- a/packages/larcoreobj/package.py
+++ b/packages/larcoreobj/package.py
@@ -29,7 +29,7 @@ class Larcoreobj(CMakePackage):
     """Larcoreobj"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/larcoreobj"
-    git_base = "https://github.com/LArSoft/larcoreobj.git"
+    git = "https://github.com/LArSoft/larcoreobj.git"
     url = "https://github.com/LArSoft/larcoreobj/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/larcoreobj/tags"
 
@@ -71,6 +71,7 @@ class Larcoreobj(CMakePackage):
         git="https://github.com/marcmengel/larcoreobj.git",
         get_full_repo=True,
     )
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"

--- a/packages/lardata/package.py
+++ b/packages/lardata/package.py
@@ -29,7 +29,7 @@ class Lardata(CMakePackage):
     """Lardata"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/lardata"
-    git_base = "https://github.com/LArSoft/lardata.git"
+    git = "https://github.com/LArSoft/lardata.git"
     url = "https://github.com/LArSoft/lardata/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/lardata/tags"
 
@@ -59,6 +59,7 @@ class Lardata(CMakePackage):
     version(
         "mwm1", tag="mwm1", git="https://github.com/marcmengel/lardata.git", get_full_repo=True
     )
+    version("develop", branch="develop", get_full_repo=True)
 
 
     def url_for_version(self, version):

--- a/packages/lardataalg/package.py
+++ b/packages/lardataalg/package.py
@@ -29,7 +29,7 @@ class Lardataalg(CMakePackage):
     """Lardataalg"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/lardataalg"
-    git_base = "https://github.com/LArSoft/lardataalg.git"
+    git = "https://github.com/LArSoft/lardataalg.git"
     url = "https://github.com/LArSoft/lardataalg/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/lardataalg/tags"
 
@@ -59,6 +59,7 @@ class Lardataalg(CMakePackage):
     version(
         "mwm1", tag="mwm1", git="https://github.com/marcmengel/lardataalg.git", get_full_repo=True
     )
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"

--- a/packages/lardataobj/package.py
+++ b/packages/lardataobj/package.py
@@ -29,7 +29,7 @@ class Lardataobj(CMakePackage):
     """Lardataobj"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/lardataobj"
-    git_base = "https://github.com/LArSoft/lardataobj.git"
+    git = "https://github.com/LArSoft/lardataobj.git"
     url = "https://github.com/LArSoft/lardataobj/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/lardataobj/tags"
 
@@ -59,6 +59,7 @@ class Lardataobj(CMakePackage):
     version(
         "mwm1", tag="mwm1", git="https://github.com/marcmengel/lardataobj.git", get_full_repo=True
     )
+    version("develop", branch="develop", get_full_repo=True)
 
     variant(
         "cxxstd",
@@ -114,7 +115,7 @@ class Lardataobj(CMakePackage):
            "-DCMAKE_CXX_STANDARD={0}".format(self.spec.variants["cxxstd"].value),
            "-Dlardataobj_FW_DIR=fw"
         ]
-       
+
         return args
 
     def setup_build_environment(self, spack_env):

--- a/packages/lareventdisplay/package.py
+++ b/packages/lareventdisplay/package.py
@@ -29,7 +29,7 @@ class Lareventdisplay(CMakePackage):
     """Lareventdisplay"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/lareventdisplay"
-    git_base = "https://github.com/LArSoft/lareventdisplay.git"
+    git = "https://github.com/LArSoft/lareventdisplay.git"
     url = "https://github.com/LArSoft/lareventdisplay/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/lareventdisplay/tags"
 
@@ -37,7 +37,7 @@ class Lareventdisplay(CMakePackage):
         "09.30.00.rc1", sha256="c479c376a2f0be7f4584c8a3d4919ad89f1b9e39a4f11a215f616cc729363d5e"
     )
     version("09.10.11", sha256="13dbdac0498248f154ee7abedd813b5f7fb43e93ef5dd8dccceddbc320ca677a")
-    version("09.10.08", sha256="b3875a4fdd011b8ad6c116e7eb8c21c7518e16bdd36eaa95ec4ad0c4f35b739c") # FIX ME
+    version("09.10.08", sha256="b3875a4fdd011b8ad6c116e7eb8c21c7518e16bdd36eaa95ec4ad0c4f35b739c")
     version("09.10.05", sha256="b79ef329c22ea79ab4e4b591b8481d6e08a8d1ec80e83973854f2dd9717e43e8")
     version(
         "09.02.08.02", sha256="fe3623fbc9438f96e66927c8c5b24114b5d0fef0f2e8dd0576b290d0fc9b4147"
@@ -60,6 +60,7 @@ class Lareventdisplay(CMakePackage):
         git="https://github.com/marcmengel/lareventdisplay.git",
         get_full_repo=True,
     )
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"

--- a/packages/larevt/package.py
+++ b/packages/larevt/package.py
@@ -29,7 +29,7 @@ class Larevt(CMakePackage):
     """Larevt"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/larevt"
-    git_base = "https://github.com/LArSoft/larevt.git"
+    git = "https://github.com/LArSoft/larevt.git"
     url = "https://github.com/LArSoft/larevt/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/larevt/tags"
 
@@ -53,6 +53,7 @@ class Larevt(CMakePackage):
     version("09.02.10", sha256="5afa7063640f2722d22cb9140f2b335043d5bb6d5ecf6e1fd3559b9d2c206b57")
     version("09.02.09", sha256="5f71d0182038e9cc096977047abf411819b0c47d5f4110fb66a2856d47ee7489")
     version("mwm1", tag="mwm1", git="https://github.com/marcmengel/larevt.git", get_full_repo=True)
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"

--- a/packages/larexamples/package.py
+++ b/packages/larexamples/package.py
@@ -29,7 +29,7 @@ class Larexamples(CMakePackage):
     """Larexamples"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/larexamples"
-    git_base = "https://github.com/LArSoft/larexamples.git"
+    git = "https://github.com/LArSoft/larexamples.git"
     url = "https://github.com/LArSoft/larexamples/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/larexamples/tags"
 
@@ -58,6 +58,7 @@ class Larexamples(CMakePackage):
     version(
         "mwm1", tag="mwm1", git="https://github.com/marcmengel/larexamples.git", get_full_repo=True
     )
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"

--- a/packages/larg4/package.py
+++ b/packages/larg4/package.py
@@ -29,7 +29,7 @@ class Larg4(CMakePackage):
     """Larg4"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/larg4"
-    git_base = "https://github.com/LArSoft/larg4.git"
+    git = "https://github.com/LArSoft/larg4.git"
     url = "https://github.com/LArSoft/larg4/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/larg4/tags"
 
@@ -54,6 +54,7 @@ class Larg4(CMakePackage):
     version("09.03.14", sha256="c6b6e06ea6affd2c49b8501bc90e6ae765bc47ef948f34334e401dca752ecc0d")
     version("09.03.13", sha256="c9f6fe589cae2cbcac9204c4a7f8f6a9f3605f66556d4e8412a50066249f709e")
     version("mwm1", tag="mwm1", git="https://github.com/marcmengel/larg4.git", get_full_repo=True)
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"

--- a/packages/larpandora/package.py
+++ b/packages/larpandora/package.py
@@ -29,7 +29,7 @@ class Larpandora(CMakePackage):
     """Larpandora"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/larpandora"
-    git_base = "https://github.com/LArSoft/larpandora.git"
+    git = "https://github.com/LArSoft/larpandora.git"
     url = "https://github.com/LArSoft/larpandora/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/larpandora/tags"
 
@@ -58,6 +58,7 @@ class Larpandora(CMakePackage):
     version(
         "mwm1", tag="mwm1", git="https://github.com/marcmengel/larpandora.git", get_full_repo=True
     )
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"

--- a/packages/larreco/package.py
+++ b/packages/larreco/package.py
@@ -29,12 +29,12 @@ class Larreco(CMakePackage):
     """Larreco"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/larreco"
-    git_base = "https://github.com/LArSoft/larreco.git"
+    git = "https://github.com/LArSoft/larreco.git"
     url = "https://github.com/LArSoft/larreco/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/larreco/tags"
 
     version("09.23.01", sha256="168dcf19c40295cc98b6549866520da78c2a1fbaf91680b41a3255793f87e232")
-    version("09.22.03", sha256="6e7c0e11bd70fb47f4f0f39e211a60dcf3c4d888415eb2cf7a48070b43aa1a7b") 
+    version("09.22.03", sha256="6e7c0e11bd70fb47f4f0f39e211a60dcf3c4d888415eb2cf7a48070b43aa1a7b")
     version("09.22.00", sha256="b7389f283b1ba23571022af44f3d62006d5b5e0c0f3d3b9f653e2d983c1d8541")
     version(
         "09.07.08.02", sha256="eba7aba2443f4c9efdb0f071db9ca6ffb7f6e0630283f235759c51586e33c449"
@@ -61,6 +61,7 @@ class Larreco(CMakePackage):
     version(
         "mwm1", tag="mwm1", git="https://github.com/marcmengel/larreco.git", get_full_repo=True
     )
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"

--- a/packages/larrecodnn/package.py
+++ b/packages/larrecodnn/package.py
@@ -29,7 +29,7 @@ class Larrecodnn(CMakePackage):
     """Larrecodnn"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/larrecodnn"
-    git_base = "https://github.com/LArSoft/larrecodnn.git"
+    git = "https://github.com/LArSoft/larrecodnn.git"
     url = "https://github.com/LArSoft/larrecodnn/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/larrecodnn/tags"
 
@@ -38,7 +38,7 @@ class Larrecodnn(CMakePackage):
         "09.30.00.rc1", sha256="c69b810f4a7027268d60f52e73da67f797491a8a0d20b80db5c9cdfe615a2e4f"
     )
     version("09.21.12", sha256="ef1c843b2de317bf6a91aa75fd3737f7fb15f6294e81b44a8f88c94261abbf0e")
-    version("09.21.09", sha256="5be674584e3cbb3835a75991786afa26603d8bece1d8e2131f8433274de14a50") # FIX ME
+    version("09.21.09", sha256="5be674584e3cbb3835a75991786afa26603d8bece1d8e2131f8433274de14a50")
     version("09.21.06", sha256="c454cabc5ed191fadb16d9b9837297f653db2affb4d7cb89677a25d6e981cd61")
     version(
         "09.09.09.02", sha256="e820f2c50899979584456bfbfcab9abe27a022bd3ad50c9436167373bda9e9af"
@@ -58,6 +58,7 @@ class Larrecodnn(CMakePackage):
     version(
         "mwm1", tag="mwm1", git="https://github.com/marcmengel/larrecodnn.git", get_full_repo=True
     )
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"

--- a/packages/larsim/package.py
+++ b/packages/larsim/package.py
@@ -29,7 +29,7 @@ class Larsim(CMakePackage):
     """Larsim"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/larsim"
-    git_base = "https://github.com/LArSoft/larsim.git"
+    git = "https://github.com/LArSoft/larsim.git"
     url = "https://github.com/LArSoft/larsim/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/larsim/tags"
 
@@ -55,6 +55,7 @@ class Larsim(CMakePackage):
     version("09.14.07", sha256="a0a235caf17b5d9d2b3959ed967a5cdb2cc1851d3d696976a656c2f48834cadc")
     version("09.14.06", sha256="5d729da4515d0315d123724b411c4e81e191ea88ed37692b5a037b7b7d94fbfb")
     version("mwm1", tag="mwm1", git="https://github.com/marcmengel/larsim.git", get_full_repo=True)
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"
@@ -111,7 +112,7 @@ class Larsim(CMakePackage):
         filter_file(r'math_tr1', '', 'CMakeLists.txt')
         filter_file(r'Boost::math_tr1', '', 'larsim/LegacyLArG4/CMakeLists.txt')
         filter_file(r'Boost::math_tr1', '', 'larsim/PhotonPropagation/CMakeLists.txt')
-        
+
 
     def cmake_args(self):
         args = [

--- a/packages/larsimdnn/package.py
+++ b/packages/larsimdnn/package.py
@@ -29,7 +29,7 @@ class Larsimdnn(CMakePackage):
     """Larsim"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/larsim"
-    git_base = "https://github.com/LArSoft/larsimdnn.git"
+    git = "https://github.com/LArSoft/larsimdnn.git"
     url = "https://github.com/LArSoft/larsimdnn/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/larsimdnn/tags"
 
@@ -37,6 +37,7 @@ class Larsimdnn(CMakePackage):
     version(
         "mwm1", tag="mwm1", git="https://github.com/marcmengel/larsimdnn.git", get_full_repo=True
     )
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"

--- a/packages/larsimrad/package.py
+++ b/packages/larsimrad/package.py
@@ -29,7 +29,7 @@ class Larsimrad(CMakePackage):
     """larsimrad"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/larsimrad"
-    git_base = "https://github.com/LArSoft/larsimrad.git"
+    git = "https://github.com/LArSoft/larsimrad.git"
     url = "https://github.com/LArSoft/larsimrad/archive/refs/tags/v09_01_17.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/larsimrad/tags"
 
@@ -57,6 +57,7 @@ class Larsimrad(CMakePackage):
     version(
         "mwm1", tag="mwm1", git="https://github.com/marcmengel/larsimrad.git", get_full_repo=True
     )
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"

--- a/packages/larsoft/package.py
+++ b/packages/larsoft/package.py
@@ -27,11 +27,11 @@ class Larsoft(CMakePackage):
     """Larsoft"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/larsoft"
-    git_base = "https://github.com/LArSoft/larsoft.git"
+    git = "https://github.com/LArSoft/larsoft.git"
     url = "https://github.com/LArSoft/larsoft/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/larsoft/tags"
     version("09.81.00", sha256="0e09c369b03b1189cc38db9d7d2ec6a711a1c8dfb99e2b0badb2726c7826aa5d")
-    version("09.78.06", sha256="3733332dcf15189688476558fc617873634e75d110fc816eb82305818a5f6f7b") 
+    version("09.78.06", sha256="3733332dcf15189688476558fc617873634e75d110fc816eb82305818a5f6f7b")
     version("09.78.00", sha256="c02d744cf66b2494316392a105c2ab8a2224ce5e33ae8e4f695054db77f13a12")
     version(
         "09.37.01.01", sha256="f9563d95c4cae3dca17c15ead61ac0e012d974b957f852d5832b15062e0d20d8"
@@ -51,6 +51,7 @@ class Larsoft(CMakePackage):
     version(
         "mwm1", tag="mwm1", git="https://github.com/marcmengel/larsoft.git", get_full_repo=True
     )
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"

--- a/packages/larsoftobj/package.py
+++ b/packages/larsoftobj/package.py
@@ -27,7 +27,7 @@ class Larsoftobj(CMakePackage):
     """Larsoftobj"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/larsoftobj"
-    git_base = "https://github.com/LArSoft/larsoftobj.git"
+    git = "https://github.com/LArSoft/larsoftobj.git"
     url = "https://github.com/LArSoft/larsoftobj/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/larsoftobj/tags"
 
@@ -59,6 +59,8 @@ class Larsoftobj(CMakePackage):
     version(
         "mwm1", tag="mwm1", git="https://github.com/marcmengel/larsoftobj.git", get_full_repo=True
     )
+    version("develop", branch="develop", get_full_repo=True)
+
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"

--- a/packages/larvecutils/package.py
+++ b/packages/larvecutils/package.py
@@ -29,7 +29,7 @@ class Larvecutils(CMakePackage):
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/larvecutils"
     url = "https://github.com/LArSoft/larvecutils.git"
-    git_base = "https://github.com/LArSoft/larvecutils.git"
+    git = "https://github.com/LArSoft/larvecutils.git"
 
     version(
         "09.00.01",
@@ -37,6 +37,7 @@ class Larvecutils(CMakePackage):
         git="https://github.com/LArSoft/larvecutils.git",
         get_full_repo=True,
     )
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/{1}.tar.gz"

--- a/packages/larwirecell/package.py
+++ b/packages/larwirecell/package.py
@@ -29,7 +29,7 @@ class Larwirecell(CMakePackage):
     """Larwirecell"""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/larwirecell"
-    git_base = "https://github.com/LArSoft/larwirecell.git"
+    git = "https://github.com/LArSoft/larwirecell.git"
     url = "https://github.com/LArSoft/larwirecell/archive/v01_02_03.tar.gz"
     list_url = "https://api.github.com/repos/LArSoft/larwirecell/tags"
 
@@ -55,6 +55,7 @@ class Larwirecell(CMakePackage):
     version(
         "mwm1", tag="mwm1", git="https://github.com/marcmengel/larwirecell.git", get_full_repo=True
     )
+    version("develop", branch="develop", get_full_repo=True)
 
     def url_for_version(self, version):
         url = "https://github.com/LArSoft/{0}/archive/v{1}.tar.gz"


### PR DESCRIPTION
Includes changing 'git_base' attribute to 'git'.