### PR TITLE
Use shutil.move instead of os.rename, as os.rename does not work across

### DIFF
--- a/packages/btrk/package.py
+++ b/packages/btrk/package.py
@@ -5,6 +5,7 @@
 
 from spack.package import *
 import os
+import shutil
 
 
 class Btrk(SConsPackage):
@@ -49,7 +50,8 @@ class Btrk(SConsPackage):
         return args
 
     def install(self, spec, prefix):
-        rename('%s/lib' % self.stage.source_path, prefix.lib)
+        move('%s/lib' % self.stage.source_path, prefix.lib)
+        #rename('%s/lib' % self.stage.source_path, prefix.lib)
         install_tree(self.stage.source_path, prefix.source)
         mkdirp(prefix.include)
         headerlist = find_all_headers(self.stage.source_path)

--- a/packages/btrk/package.py
+++ b/packages/btrk/package.py
@@ -51,7 +51,6 @@ class Btrk(SConsPackage):
 
     def install(self, spec, prefix):
         move('%s/lib' % self.stage.source_path, prefix.lib)
-        #rename('%s/lib' % self.stage.source_path, prefix.lib)
         install_tree(self.stage.source_path, prefix.source)
         mkdirp(prefix.include)
         headerlist = find_all_headers(self.stage.source_path)


### PR DESCRIPTION
different filesystems (e.g. /tmp to /home)