### PR TITLE
Add cxxstd_variant to remove boilerplate

### DIFF
--- a/packages/art-root-io/package.py
+++ b/packages/art-root-io/package.py
@@ -33,14 +33,7 @@ class ArtRootIo(CMakePackage, FnalGithubPackage):
     version("1.08.05", sha256="77f58e4200f699dcb324a3a9fc9e59562d2a1721a34a6db43fdb435853890d21")
     version("1.08.03", sha256="fefdb0803bc139a65339d9fa1509f2e9be1c5613b64ec1ec84e99f404663e4bf")
 
-    variant(
-        "cxxstd",
-        default="17",
-        values=("17", "20", "23"),
-        multi=False,
-        sticky=True,
-        description="C++ standard",
-    )
+    cxxstd_variant("17", "20", "23", default="17", sticky=True)
     conflicts("cxxstd=17", when="@1.14.00:")
 
     depends_on("art")

--- a/packages/art/package.py
+++ b/packages/art/package.py
@@ -38,14 +38,7 @@ class Art(CMakePackage, FnalGithubPackage):
     version("3.04.00", sha256="38d27e1776adad157ad2d4e8c073ecda67ec4677fff9ebbffef6e37d7ed1d8ff")
     version("develop", branch="develop", get_full_repo=True)
 
-    variant(
-        "cxxstd",
-        default="17",
-        values=("17", "20", "23"),
-        multi=False,
-        sticky=True,
-        description="C++ standard",
-    )
+    cxxstd_variant("17", "20", "23", default="17", sticky=True)
     conflicts("cxxstd=17", when="@3.15.00:")
 
     depends_on("boost+date_time+graph+program_options+regex")

--- a/packages/canvas-root-io/package.py
+++ b/packages/canvas-root-io/package.py
@@ -34,14 +34,7 @@ class CanvasRootIo(CMakePackage, FnalGithubPackage):
 
     patch("test_build.patch", when="@:1.11.00")
 
-    variant(
-        "cxxstd",
-        default="17",
-        values=("17", "20", "23"),
-        multi=False,
-        sticky=True,
-        description="C++ standard",
-    )
+    cxxstd_variant("17", "20", "23", default="17", sticky=True)
     conflicts("cxxstd=17", when="@1.14.00:")
 
     depends_on("boost+thread")

--- a/packages/canvas/package.py
+++ b/packages/canvas/package.py
@@ -31,15 +31,7 @@ class Canvas(CMakePackage, FnalGithubPackage):
 
     version("develop", branch="develop", get_full_repo=True)
 
-    variant(
-        "cxxstd",
-        default="17",
-        values=("17", "20", "23"),
-        multi=False,
-        sticky=True,
-        description="C++ standard",
-    )
-    conflicts("cxxstd=17", when="@3.17.00:")
+    cxxstd_variant("17", "20", "23", default="17", sticky=True)
 
     depends_on("boost+date_time+test")
     depends_on("cetlib")

--- a/packages/cetlib-except/package.py
+++ b/packages/cetlib-except/package.py
@@ -25,14 +25,7 @@ class CetlibExcept(CMakePackage, FnalGithubPackage):
     version("1.07.04", sha256="d021d26fda9f4f57b57850bc6f5ac0a79aed913ef1cde68a96838ad85d332d70")
     version("develop", branch="develop", get_full_repo=True)
 
-    variant(
-        "cxxstd",
-        default="17",
-        values=("17", "20", "23"),
-        multi=False,
-        sticky=True,
-        description="C++ standard",
-    )
+    cxxstd_variant("17", "20", "23", default="17", sticky=True)
     conflicts("cxxstd=17", when="@1.10.00:")
 
     depends_on("catch2@2.3.0:2", when="@:1.08", type=("build", "test"))

--- a/packages/cetlib/package.py
+++ b/packages/cetlib/package.py
@@ -29,14 +29,7 @@ class Cetlib(CMakePackage, FnalGithubPackage):
     version("3.13.04", sha256="40ca829cfb172f6cbf516bd3427fc7b7e893f9c916d969800261194610c45edf")
     version("develop", branch="develop", get_full_repo=True)
 
-    variant(
-        "cxxstd",
-        default="17",
-        values=("17", "20", "23"),
-        multi=False,
-        sticky=True,
-        description="C++ standard",
-    )
+    cxxstd_variant("17", "20", "23", default="17", sticky=True)
     conflicts("cxxstd=17", when="@3.19.00:")
 
     patch("test_build.patch", when="@:3.16.00")

--- a/packages/critic/package.py
+++ b/packages/critic/package.py
@@ -47,14 +47,7 @@ class Critic(CMakePackage, FnalGithubPackage):
     version("2.12.03", sha256="13ae221a5060eb37de3c57c3b74e707c3bb2bd6352995fc640bfbb6e841bcfca")
     version("2.12.02", sha256="9dc9e20c97ecd7e967851546dc12dde9a9768b95c14b8f5c64b0ef11a158730d")
 
-    variant(
-        "cxxstd",
-        default="17",
-        values=("17", "20", "23"),
-        multi=False,
-        sticky=True,
-        description="C++ standard",
-    )
+    cxxstd_variant("17", "20", "23", default="17", sticky=True)
     conflicts("cxxstd=17", when="@2.14.00:")
 
     depends_on("art")

--- a/packages/fhicl-cpp/package.py
+++ b/packages/fhicl-cpp/package.py
@@ -29,14 +29,7 @@ class FhiclCpp(CMakePackage, FnalGithubPackage):
     version("4.15.03", sha256="99ae2b7557c671d0207dea96529e7c0fca2274974b6609cc7c6bf7e8d04bd12b")
     version("develop", branch="develop", get_full_repo=True)
 
-    variant(
-        "cxxstd",
-        default="17",
-        values=("17", "20", "23"),
-        multi=False,
-        sticky=True,
-        description="C++ standard",
-    )
+    cxxstd_variant("17", "20", "23", default="17", sticky=True)
     conflicts("cxxstd=17", when="@4.19.00:")
 
     depends_on("boost+program_options+test")

--- a/packages/fnal-github-package/package.py
+++ b/packages/fnal-github-package/package.py
@@ -5,6 +5,7 @@
 
 import llnl.util.tty as tty
 import spack.util.spack_json as sjson
+from spack.directives import variant
 from spack.util.environment import PrependPath
 from spack.package import *
 from spack.version import *
@@ -68,6 +69,26 @@ def fetch_remote_tags(organization, repo_name, url):
         dotted_version_str(d["name"]): github_version_url(organization, repo_name, d["name"])
         for d in sjson.load(request)
     }
+
+
+# wrapped variant to remove boilerplate for "cxxstd"
+_disallowed_kwargs = {"multi", "description", "values"}
+
+
+def cxxstd_variant(*cxxstd_options, **kwargs):
+    disallowed_present = set(kwargs.keys()) & _disallowed_kwargs
+    if disallowed_present:
+        tty.die(
+            f"The following keyword arguments cannot be specified to cxxstd_variant: {disallowed_present}"
+        )
+
+    variant(
+        "cxxstd",
+        values=cxxstd_options,
+        **kwargs,
+        multi=False,
+        description="Use the specified C++ standard when building.",
+    )
 
 
 class FnalGithubPackage(Package):

--- a/packages/gallery/package.py
+++ b/packages/gallery/package.py
@@ -30,14 +30,7 @@ class Gallery(CMakePackage, FnalGithubPackage):
     version("1.21.03", sha256="b1f41e1e4efcaf73b6c90c12dc513217ea5591ce369a9335d2ca6f4d0f2b1728")
     version("1.20.02", sha256="433e2b5727b9d9cf47206d9a01db5eab27c5cbb76407bb0ec14c0fd4e4dc41f9")
 
-    variant(
-        "cxxstd",
-        default="17",
-        values=("17", "20", "23"),
-        multi=False,
-        sticky=True,
-        description="C++ standard",
-    )
+    cxxstd_variant("17", "20", "23", default="17", sticky=True)
     conflicts("cxxstd=17", when="@1.23.00:")
 
     depends_on("canvas")

--- a/packages/hep-concurrency/package.py
+++ b/packages/hep-concurrency/package.py
@@ -25,14 +25,7 @@ class HepConcurrency(CMakePackage, FnalGithubPackage):
     version("1.07.04", sha256="442db7ea3c0057e86165a001ef77c1fc0e5ed65c62fd1dd53e68fb8fe9a5fef3")
     version("develop", branch="develop", get_full_repo=True)
 
-    variant(
-        "cxxstd",
-        default="17",
-        values=("17", "20", "23"),
-        multi=False,
-        sticky=True,
-        description="C++ standard",
-    )
+    cxxstd_variant("17", "20", "23", default="17", sticky=True)
     conflicts("cxxstd=17", when="@1.10.00:")
 
     depends_on("catch2@2.3.0:2", when="@:1.08", type=("build", "test"))

--- a/packages/messagefacility/package.py
+++ b/packages/messagefacility/package.py
@@ -31,14 +31,7 @@ class Messagefacility(CMakePackage, FnalGithubPackage):
     version("2.08.00", sha256="a2c833071dfe7538c40a0024d15f19ba062fd5f56b26f83f5cb739c12ff860ec")
     version("develop", branch="develop")
 
-    variant(
-        "cxxstd",
-        default="17",
-        values=("17", "20", "23"),
-        multi=False,
-        sticky=True,
-        description="C++ standard",
-    )
+    cxxstd_variant("17", "20", "23", default="17", sticky=True)
     conflicts("cxxstd=17", when="@2.11.00:")
 
     depends_on("boost+filesystem+program_options+system")


### PR DESCRIPTION
This facility enables the following replacement

```diff
-    variant(
-        "cxxstd",
-        default="17",
-        values=("17", "20", "23"),
-        multi=False,
-        sticky=True,
-        description="C++ standard",
-    )
+    cxxstd_variant("17", "20", "23", default="17", sticky=True)
```