### PR TITLE
Avoid using Boost versions that break building existing art releases

### DIFF
--- a/packages/art-root-io/package.py
+++ b/packages/art-root-io/package.py
@@ -37,6 +37,7 @@ class ArtRootIo(CMakePackage, FnalGithubPackage):
     conflicts("cxxstd=17", when="@1.14.00:")
 
     depends_on("art")
+    depends_on("boost@:1.82", when="@:1.14")
     depends_on("boost+filesystem+date_time+program_options")
     depends_on("canvas")
     depends_on("canvas-root-io")

--- a/packages/art/package.py
+++ b/packages/art/package.py
@@ -41,6 +41,7 @@ class Art(CMakePackage, FnalGithubPackage):
     cxxstd_variant("17", "20", "23", default="17", sticky=True)
     conflicts("cxxstd=17", when="@3.15.00:")
 
+    depends_on("boost@:1.82", when="@:3.15")
     depends_on("boost+date_time+graph+program_options+regex")
     depends_on("boost@1.75: +filesystem+json+test+thread", type=("build"))
     depends_on("boost+graph+test", type=("test"))

--- a/packages/fhicl-cpp/package.py
+++ b/packages/fhicl-cpp/package.py
@@ -32,6 +32,7 @@ class FhiclCpp(CMakePackage, FnalGithubPackage):
     cxxstd_variant("17", "20", "23", default="17", sticky=True)
     conflicts("cxxstd=17", when="@4.19.00:")
 
+    depends_on("boost@:1.82", when="@:4.19")
     depends_on("boost+program_options+test")
     depends_on("cetlib")
     depends_on("cetlib-except")


### PR DESCRIPTION
With Boost 1.83 and newer, the `<cassert>` header is no longer provided for transitive use in art and friends.  These header includes have now been added in the appropriate places, but we should prevent Spack from concretizing Boost versions that break the builds for existing art releases.