### PR TITLE
Constrain GCC version for canvas-root-io 1.09

### DIFF
--- a/packages/canvas-root-io/package.py
+++ b/packages/canvas-root-io/package.py
@@ -34,6 +34,8 @@ class CanvasRootIo(CMakePackage, FnalGithubPackage):
 
     patch("test_build.patch", when="@:1.11.00")
 
+    requires("%gcc@:12", when="@:1.09")
+
     cxxstd_variant("17", "20", "23", default="17", sticky=True)
     conflicts("cxxstd=17", when="@1.14.00:")
 


### PR DESCRIPTION
canvas-root-io 1.09 does not build with GCC 13.