### PR TITLE
updates and fixes for GENIE recipe

### DIFF
--- a/packages/genie/package.py
+++ b/packages/genie/package.py
@@ -88,18 +88,6 @@ class Genie(AutotoolsPackage):
     def patch(self):
         filter_file(r'-lnsl','','src/make/Make.include')
 
-    @property
-    def build_targets(self):
-        cxxstd = self.spec.variants["cxxstd"].value
-        cxxstdflag = (
-            "" if cxxstd == "default" else getattr(self.compiler, "cxx{0}_flag".format(cxxstd))
-        )
-        args = [
-            "GOPT_WITH_CXX_USERDEF_FLAGS=-g -fno-omit-frame-pointer {0}".format(cxxstdflag),
-            "all",
-        ]
-        return args
-
     def configure_args(self):
         args = [
             "--enable-rwght",
@@ -164,9 +152,9 @@ class Genie(AutotoolsPackage):
 
     def build(self, spec, prefix):
         with working_dir(self.build_directory):
-            make(*self.build_targets)
+            make()
         with working_dir("{0}/Reweight".format(self.stage.source_path)):
-            make(*self.build_targets)
+            make()
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
@@ -203,6 +191,13 @@ class Genie(AutotoolsPackage):
             direction="children",
         ):
             spack_env.prepend_path("ROOT_INCLUDE_PATH", str(self.spec[d.name].prefix.include))
+
+        # set compiler flags
+        cxxstd = self.spec.variants["cxxstd"].value
+        cxxstdflag = (
+            "" if cxxstd == "default" else getattr(self.compiler, "cxx{0}_flag".format(cxxstd))
+        )
+        spack_env.set("CXXFLAGS", f"-g -fno-omit-frame-pointer {cxxstdflag}")
 
     def setup_run_environment(self, run_env):
         run_env.prepend_path("PATH", self.prefix.bin)

--- a/packages/genie/package.py
+++ b/packages/genie/package.py
@@ -107,7 +107,7 @@ class Genie(AutotoolsPackage):
             "--enable-atmo",
             "--enable-event-server",
             "--enable-nucleon-decay",
-            "--enable-neutron-osc",
+            "--enable-nnbar-oscillation",
             "--enable-vle-extension",
             "--with-pythia6-lib={0}".format(self.spec["pythia6"].prefix.lib),
             "--with-libxml2-inc={0}/libxml2".format(self.spec["libxml2"].prefix.include),

--- a/packages/genie/package.py
+++ b/packages/genie/package.py
@@ -96,7 +96,6 @@ class Genie(AutotoolsPackage):
             "--enable-event-server",
             "--enable-nucleon-decay",
             "--enable-nnbar-oscillation",
-            "--enable-vle-extension",
             "--with-pythia6-lib={0}".format(self.spec["pythia6"].prefix.lib),
             "--with-libxml2-inc={0}/libxml2".format(self.spec["libxml2"].prefix.include),
             "--with-libxml2-lib={0}".format(self.spec["libxml2"].prefix.lib),

--- a/packages/genie/package.py
+++ b/packages/genie/package.py
@@ -191,12 +191,12 @@ class Genie(AutotoolsPackage):
         ):
             spack_env.prepend_path("ROOT_INCLUDE_PATH", str(self.spec[d.name].prefix.include))
 
-        # set compiler flags
-        cxxstd = self.spec.variants["cxxstd"].value
-        cxxstdflag = (
-            "" if cxxstd == "default" else getattr(self.compiler, "cxx{0}_flag".format(cxxstd))
-        )
-        spack_env.set("CXXFLAGS", f"-g -fno-omit-frame-pointer {cxxstdflag}")
+    def flag_handler(self, name, flags):
+        if name == "cxxflags":
+            cxxstd = self.spec.variants["cxxstd"].value
+            if cxxstd != "default":
+                flags.append(getattr(self.compiler, f"cxx{cxxstd}_flag"))
+        return (flags, None, None)
 
     def setup_run_environment(self, run_env):
         run_env.prepend_path("PATH", self.prefix.bin)


### PR DESCRIPTION
as we work to build out the NOvA stack, I was running into some issues building the GENIE package and needed to make a couple of tweaks to its recipe. i was running into an issue with C++ compiler flags, and i was able to resolve it by exporting `CXXFLAGS` instead of hacking the compiler flags into the build targets, which was leading to a collision with the default compiler flags. while i was in there, i also noticed a couple of configure flags that weren't being set correctly for GENIE v3 and updated them.