### PR TITLE
add CAFAna package recipes

### DIFF
--- a/packages/cafanacore/package.py
+++ b/packages/cafanacore/package.py
@@ -1,0 +1,45 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Cafanacore(CMakePackage):
+    """Base libraries of the CAFAna analysis framework"""
+
+    homepage = "https://github.com/cafana/CAFAnaCore"
+    git = "https://github.com/cafana/CAFAnaCore"
+
+    maintainers("vhewes")
+
+    version("develop", branch="main")
+
+    variant("stan", default=True, description="Build with Stan Math support")
+    variant("ifdhc", default=True, description="Build with IFDHC support")
+
+    depends_on("cetmodules", type="build")
+    depends_on("boost")
+    depends_on("osclib")
+    depends_on("osclib+stan", when="+stan")
+    depends_on("stan-math")
+    depends_on("ifdhc", when="+ifdhc")
+
+    def setup_build_environment(self, env):
+        # stan-math
+        env.set("STAN_MATH_INC", self.spec["stan-math"].prefix)
+
+        # ifdhc
+        if self.spec.satisfies("+ifdhc"):
+            env.set("IFDHC_DIR", self.spec["ifdhc"].prefix)
+            env.set("IFDHC_FQ_DIR", self.spec["ifdhc"].prefix)
+            env.set("IFDHC_VERSION", self.spec["ifdhc"].version)
+            env.set("IFDHC_LIB", self.spec["ifdhc"].prefix.lib)
+
+    def cmake_args(self):
+        return [
+            self.define("NO_IFDHC", self.spec.satisfies("~ifdhc")),
+            self.define_from_variant("STAN", "stan")
+        ]
+        

--- a/packages/cafanacore/package.py
+++ b/packages/cafanacore/package.py
@@ -10,14 +10,16 @@ class Cafanacore(CMakePackage):
     """Base libraries of the CAFAna analysis framework"""
 
     homepage = "https://github.com/cafana/CAFAnaCore"
-    git = "https://github.com/cafana/CAFAnaCore"
+    url = "https://github.com/cafana/CAFAnaCore/archive/v02.01.tar.gz"
 
     maintainers("vhewes")
 
-    version("develop", branch="main")
+    version("02.01", sha256="cb747ef71586bead03233ef58ad038c8e133b7c210971e8e6ba6df0cbef7e1ae")
 
     variant("stan", default=True, description="Build with Stan Math support")
     variant("ifdhc", default=True, description="Build with IFDHC support")
+    variant("cxxstd", values=("17", "20", "23"), default="17", multi=False,
+            sticky=True, description="C++ standard")
 
     depends_on("cetmodules", type="build")
     depends_on("boost")
@@ -27,19 +29,28 @@ class Cafanacore(CMakePackage):
     depends_on("ifdhc", when="+ifdhc")
 
     def setup_build_environment(self, env):
+
         # stan-math
+        env.set("STAN_MATH_DIR", self.spec["stan-math"].prefix)
+        env.set("STAN_MATH_VERSION", self.spec["stan-math"].version)
         env.set("STAN_MATH_INC", self.spec["stan-math"].prefix)
+
+        # sundials
+        env.set("SUNDIALS_INC", self.spec["sundials"].prefix.include)
 
         # ifdhc
         if self.spec.satisfies("+ifdhc"):
             env.set("IFDHC_DIR", self.spec["ifdhc"].prefix)
             env.set("IFDHC_FQ_DIR", self.spec["ifdhc"].prefix)
             env.set("IFDHC_VERSION", self.spec["ifdhc"].version)
+            env.set("IFDHC_INC", self.spec["ifdhc"].prefix.inc)
             env.set("IFDHC_LIB", self.spec["ifdhc"].prefix.lib)
 
     def cmake_args(self):
         return [
+            self.define("SPACK", "YES"),
+            self.define("CAFANACORE_VERSION", self.spec.version),
             self.define("NO_IFDHC", self.spec.satisfies("~ifdhc")),
-            self.define_from_variant("STAN", "stan")
+            self.define_from_variant("STAN", "stan"),
+            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
         ]
-        

--- a/packages/osclib/package.py
+++ b/packages/osclib/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Osclib(CMakePackage):
+    """Neutrino oscillation probability tools."""
+
+    homepage = "https://github.com/cafana/OscLib"
+    url = "https://github.com/cafana/OscLib/archive/v00.25.tar.gz"
+
+    maintainers("vhewes")
+
+    version("00.25", sha256="ee4f4120e414acb065ad967bda9de12e7a5594e6539b25b721084c8f112a3f4c")
+
+    depends_on("cetmodules", type="build")
+
+    depends_on("root")
+    depends_on("boost")
+    depends_on("eigen")
+
+    with when("+stan"):
+        depends_on("stan-math")
+        depends_on("intel-tbb@2020.3")
+
+    variant("stan", default=True, description="Build with Stan dependency")
+
+    def setup_build_environment(self, env):
+        # need to set up STAN_MATH_INC so Findstan_math.cmake will work as-is
+        if self.spec.satisfies("+stan"):
+            env.set("STAN_MATH_INC", self.spec["stan-math"].prefix)
+
+    def cmake_args(self):
+        return [self.define_from_variant("STAN", "stan")]

--- a/packages/stan-math/package.py
+++ b/packages/stan-math/package.py
@@ -3,55 +3,30 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install stan-math
-#
-# You can edit this file again by typing:
-#
-#     spack edit stan-math
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
-import os
-
 from spack import *
 
 
 class StanMath(Package):
-    """FIXME: Put a proper description of your package here."""
+    """C++ template library for automatic differentiation"""
 
-    # FIXME: Add a proper url for your package's homepage here.
-    homepage = "https://www.example.com"
+    homepage = "https://mc-stan.org/math"
     url = "https://github.com/stan-dev/math/archive/v4.0.0.tar.gz"
 
-    # FIXME: Add a list of GitHub accounts to
-    # notify when the package is updated.
-    # maintainers = ['github_user1', 'github_user2']
+    maintainers("vhewes")
 
     version("4.0.0", sha256="99ccd238eb2421be55d290a858ab5aa31022eded5c66201fcee35b2638f0bb42")
-    version("3.5.0-rc1", sha256="f867613f8b908a02aac1df196d028bd1aad2c19bb40f2b454940ef7dfaeecfdc")
-    version("3.4.0-rc1", sha256="59703645dc5b1fe7e3dab71737a282ed4dd4938f80100c8736e072d6c2ecb001")
     version("3.4.0", sha256="3e768d1c2692543d3560f9d954d19e58fd14c9aaca22f5140c9f7f1437ddccf9")
     version("3.3.0", sha256="fb96629fd3e5e06f0ad4c03a774e54b045cc1dcfde5ff65b6f78f0f05772770a")
+
+    depends_on("boost")
+    depends_on("eigen")
+    depends_on("intel-tbb@2020.3")
+    depends_on("sundials@6.1")
 
     def install(self, spec, prefix):
         # NOTE: there are some tests that require building, but these are mostly
         #       targeted at Stan developers.
         #       We're just going to unwind the tarball and install the headers,
         #       which are all users need
-
-        # lib contains a bunch of library dependencies that we're
-        # obtaining via Spack instead
-        os.system("rm -rf lib")
-        install_tree(self.stage.source_path, prefix)
-
-    def setup_build_environment(self, spack_env):
-        pass
+        mkdir(prefix.stan)
+        install_tree("stan", prefix.stan)

--- a/packages/stan-math/package.py
+++ b/packages/stan-math/package.py
@@ -14,6 +14,12 @@ class StanMath(Package):
 
     maintainers("vhewes")
 
+    version("4.9.0", sha256="876881b71dee6fec32f2b4aa52692994cccd2a19c6de1b986d7fc457155f219c")
+    version("4.8.1", sha256="78e115c89c298fb9e6fa5941b7e39c84cfea0a8f491a0dc556ab5746d5699136")
+    version("4.8.0", sha256="b707737c8ce6833cf2b0d279f380c0d7fd47c76288578982dafeabf583b738c1")
+    version("4.7.0", sha256="c314325d20c3f4a3b6eda31b41f84f71c3fff9521906b5c3ff671e5702ded92f")
+    version("4.6.2", sha256="30df8657e02ddc77b6c96ac32f8d6f099a61064a113373cd3a11ffd736372ba1")
+    version("4.6.1", sha256="2df2be173e922b2794e0457f537fe0b0276a66515051cbb8c61e488cfe12f795")
     version("4.0.0", sha256="99ccd238eb2421be55d290a858ab5aa31022eded5c66201fcee35b2638f0bb42")
     version("3.4.0", sha256="3e768d1c2692543d3560f9d954d19e58fd14c9aaca22f5140c9f7f1437ddccf9")
     version("3.3.0", sha256="fb96629fd3e5e06f0ad4c03a774e54b045cc1dcfde5ff65b6f78f0f05772770a")

--- a/packages/stan-math/package.py
+++ b/packages/stan-math/package.py
@@ -27,7 +27,7 @@ class StanMath(Package):
     depends_on("boost")
     depends_on("eigen")
     depends_on("intel-tbb@2020.3")
-    depends_on("sundials@6.1")
+    depends_on("sundials@6.1~examples~examples-install")
 
     def install(self, spec, prefix):
         # NOTE: there are some tests that require building, but these are mostly

--- a/packages/stan/package.py
+++ b/packages/stan/package.py
@@ -7,27 +7,18 @@ from spack import *
 
 
 class Stan(Package):
-    """FIXME: Put a proper description of your package here."""
+    """C++ package for Bayesian inference"""
 
     homepage = "https://mc-stan.org/"
     url = "https://github.com/stan-dev/stan/archive/v2.26.0.tar.gz"
 
     maintainers = ["marc.mengel@gmail.com"]
 
-    version(
-        "2.26.0-rc1", sha256="a0328ba63267c7417185af390613b8ce4e833766e5c7441f615eaa8ec7da3cbe"
-    )
     version("2.26.0", sha256="3b6ff0cbeddaa5b0f94692862d7a2266d12c3e7a6833ea0f5c7c20ff7b28907a")
-    version(
-        "2.25.0-rc1", sha256="9b34c1d1ff11c7e9d8b67ec6d8b685e7a92b6711dd63c04e65e3d35780d22bed"
-    )
     version("2.25.0", sha256="9c2f936be00f28f95b58e061e95b5a81990b978001eb9df5b03f7803906b1d78")
     version("2.24.0", sha256="f398098eb030036d23b2a8e131598bc89c2e4fa5e85be9ab1d0a8b0d91739f99")
 
-    def install(self, spec, prefix):
-        install_tree(self.stage.source_path + "/src/stan", prefix.include)
+    depends_on("stan-math")
 
-    def setup_run_environment(self, run_env):
-        # run_env.prepend_path('PYTHONPATH', self.prefix.bin)
-        # run_env.prepend_path('PYTHONPATH', self.prefix + '/python')
-        pass
+    def install(self, spec, prefix):
+        install_tree("src", prefix.include)


### PR DESCRIPTION
this PR adds package recipes for the OscLib and CAFAnaCore analysis packages, added here in the context of NOvA but also used by LAr experiments such as SBN and DUNE. i've also overhauled and cleaned up the `stan` and `stan-math` package recipes, which were a little hacked together and weren't working well out of the box.

i'm still working on finalizing the NOvA stack, so it's possible there will be more changes to these recipes at some point down the road, but i think they're mature enough to be propagated back into the main development branch.