### PR TITLE
Make sure to import package base classes

### DIFF
--- a/packages/art-cpp-db-interfaces/package.py
+++ b/packages/art-cpp-db-interfaces/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class ArtCppDbInterfaces(Package):

--- a/packages/art/package.py
+++ b/packages/art/package.py
@@ -6,6 +6,7 @@
 import os
 
 from spack import *
+from spack.package import *
 from spack.pkg.fnal_art.fnal_github_package import *
 from spack.util.prefix import Prefix
 

--- a/packages/artg4/package.py
+++ b/packages/artg4/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class Artg4(CMakePackage):

--- a/packages/artg4tk/package.py
+++ b/packages/artg4tk/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class Artg4tk(CMakePackage):

--- a/packages/bxdecay0/package.py
+++ b/packages/bxdecay0/package.py
@@ -7,6 +7,7 @@ import os
 
 import spack.util.spack_json as sjson
 from spack import *
+from spack.package import *
 
 
 def sanitize_environments(*args):

--- a/packages/cadmesh/package.py
+++ b/packages/cadmesh/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class Cadmesh(CMakePackage):

--- a/packages/castxml/package.py
+++ b/packages/castxml/package.py
@@ -21,6 +21,7 @@
 # ----------------------------------------------------------------------------
 
 from spack import *
+from spack.package import *
 
 
 class Castxml(CMakePackage):

--- a/packages/cetbuildtools/package.py
+++ b/packages/cetbuildtools/package.py
@@ -22,6 +22,7 @@
 
 import spack.util.spack_json as sjson
 from spack import *
+from spack.package import *
 
 
 class Cetbuildtools(CMakePackage):

--- a/packages/cetpkgsupport/package.py
+++ b/packages/cetpkgsupport/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class Cetpkgsupport(CMakePackage):

--- a/packages/cosmosis/package.py
+++ b/packages/cosmosis/package.py
@@ -6,6 +6,7 @@
 import os
 
 from spack import *
+from spack.package import *
 
 
 class Cosmosis(MakefilePackage):

--- a/packages/crc32c/package.py
+++ b/packages/crc32c/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Crc32c(CMakePackage):

--- a/packages/cry/package.py
+++ b/packages/cry/package.py
@@ -9,6 +9,7 @@ import os
 import sys
 
 from spack import *
+from spack.package import *
 
 libdir = "%s/var/spack/repos/fnal_art/lib" % os.environ["SPACK_ROOT"]
 if libdir not in sys.path:

--- a/packages/dunetpc/package.py
+++ b/packages/dunetpc/package.py
@@ -7,6 +7,7 @@
 import os
 
 from spack import *
+from spack.package import *
 
 
 def sanitize_environments(*args):

--- a/packages/genie-phyopt/package.py
+++ b/packages/genie-phyopt/package.py
@@ -7,6 +7,7 @@
 import os
 
 from spack import *
+from spack.package import *
 
 
 class GeniePhyopt(Package):

--- a/packages/genie-xsec/package.py
+++ b/packages/genie-xsec/package.py
@@ -6,6 +6,7 @@
 import os
 
 from spack import *
+from spack.package import *
 
 
 class GenieXsec(Package):

--- a/packages/genie/package.py
+++ b/packages/genie/package.py
@@ -9,6 +9,7 @@ import os
 from llnl.util import filesystem
 
 from spack import *
+from spack.package import *
 
 
 class Genie(AutotoolsPackage):

--- a/packages/gitflow/package.py
+++ b/packages/gitflow/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class Gitflow(Package):

--- a/packages/gm2/package.py
+++ b/packages/gm2/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Gm2(Package):

--- a/packages/gm2analyses/package.py
+++ b/packages/gm2analyses/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class Gm2analyses(CMakePackage):

--- a/packages/gm2aux/package.py
+++ b/packages/gm2aux/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Gm2aux(CMakePackage):

--- a/packages/gm2calo/package.py
+++ b/packages/gm2calo/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class Gm2calo(CMakePackage):

--- a/packages/gm2dataproducts/package.py
+++ b/packages/gm2dataproducts/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Gm2dataproducts(CMakePackage):

--- a/packages/gm2db/package.py
+++ b/packages/gm2db/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Gm2db(CMakePackage):

--- a/packages/gm2field/package.py
+++ b/packages/gm2field/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Gm2field(CMakePackage):

--- a/packages/gm2fieldsignal/package.py
+++ b/packages/gm2fieldsignal/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Gm2fieldsignal(CMakePackage):

--- a/packages/gm2geom/package.py
+++ b/packages/gm2geom/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Gm2geom(CMakePackage):

--- a/packages/gm2midastoart/package.py
+++ b/packages/gm2midastoart/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Gm2midastoart(CMakePackage):

--- a/packages/gm2pip/package.py
+++ b/packages/gm2pip/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Gm2pip(Package):

--- a/packages/gm2reconeast/package.py
+++ b/packages/gm2reconeast/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Gm2reconeast(CMakePackage):

--- a/packages/gm2ringsim/package.py
+++ b/packages/gm2ringsim/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Gm2ringsim(CMakePackage):

--- a/packages/gm2templates/package.py
+++ b/packages/gm2templates/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Gm2templates(CMakePackage):

--- a/packages/gm2tracker/package.py
+++ b/packages/gm2tracker/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Gm2tracker(CMakePackage):

--- a/packages/gm2trackerdaq/package.py
+++ b/packages/gm2trackerdaq/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Gm2trackerdaq(CMakePackage):

--- a/packages/gm2unpackers/package.py
+++ b/packages/gm2unpackers/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Gm2unpackers(CMakePackage):

--- a/packages/gm2util/package.py
+++ b/packages/gm2util/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Gm2util(CMakePackage):

--- a/packages/google-benchmark/package.py
+++ b/packages/google-benchmark/package.py
@@ -5,6 +5,8 @@
 
 
 from spack import *
+from spack.package import *
+
 
 class GoogleBenchmark(CMakePackage):
     """FIXME: Put a proper description of your package here."""

--- a/packages/google-cloud-cpp/package.py
+++ b/packages/google-cloud-cpp/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class GoogleCloudCpp(CMakePackage):

--- a/packages/h5cpp/package.py
+++ b/packages/h5cpp/package.py
@@ -6,6 +6,7 @@
 import re
 
 from spack import *
+from spack.package import *
 
 
 class H5cpp(Package):

--- a/packages/icarus-data/package.py
+++ b/packages/icarus-data/package.py
@@ -1,6 +1,7 @@
 import glob
 
 from spack import *
+from spack.package import *
 
 
 class IcarusData(Package):

--- a/packages/icarus-signal-processing/package.py
+++ b/packages/icarus-signal-processing/package.py
@@ -7,6 +7,7 @@ import os
 
 import spack.util.spack_json as sjson
 from spack import *
+from spack.package import *
 
 
 def sanitize_environments(*args):

--- a/packages/icarusalg/package.py
+++ b/packages/icarusalg/package.py
@@ -7,6 +7,7 @@ import os
 
 import spack.util.spack_json as sjson
 from spack import *
+from spack.package import *
 
 
 def sanitize_environments(*args):

--- a/packages/icaruscode/package.py
+++ b/packages/icaruscode/package.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 from spack import *
+from spack.package import *
 
 libdir = "%s/var/spack/repos/fnal_art/lib" % os.environ["SPACK_ROOT"]
 if libdir not in sys.path:

--- a/packages/icarusutil/package.py
+++ b/packages/icarusutil/package.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 from spack import *
+from spack.package import *
 
 libdir = "%s/var/spack/repos/fnal_art/lib" % os.environ["SPACK_ROOT"]
 if libdir not in sys.path:

--- a/packages/ifbeam/package.py
+++ b/packages/ifbeam/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class Ifbeam(MakefilePackage):

--- a/packages/ifdh-art/package.py
+++ b/packages/ifdh-art/package.py
@@ -5,6 +5,7 @@
 
 import spack.util.spack_json as sjson
 from spack import *
+from spack.package import *
 
 
 def sanitize_environments(*args):

--- a/packages/ifdhc-config/package.py
+++ b/packages/ifdhc-config/package.py
@@ -8,6 +8,7 @@ import os
 import llnl.util.tty as tty
 
 from spack import *
+from spack.package import *
 
 
 class IfdhcConfig(Package):

--- a/packages/ifdhc/package.py
+++ b/packages/ifdhc/package.py
@@ -8,6 +8,7 @@ import os
 import llnl.util.tty as tty
 
 from spack import *
+from spack.package import *
 
 
 class Ifdhc(MakefilePackage):

--- a/packages/intel-tbb-oneapi/package.py
+++ b/packages/intel-tbb-oneapi/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class IntelTbbOneapi(CMakePackage):

--- a/packages/jsonnet/package.py
+++ b/packages/jsonnet/package.py
@@ -3,8 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 import os
+
+from spack import *
+from spack.package import *
 
 
 class Jsonnet(Package):

--- a/packages/libb64/package.py
+++ b/packages/libb64/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Libb64(MakefilePackage):

--- a/packages/libevhtp/package.py
+++ b/packages/libevhtp/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class Libevhtp(CMakePackage):

--- a/packages/libpqxx/package.py
+++ b/packages/libpqxx/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class Libpqxx(CMakePackage):

--- a/packages/libwda/package.py
+++ b/packages/libwda/package.py
@@ -6,6 +6,7 @@
 import os
 
 from spack import *
+from spack.package import *
 
 
 class Libwda(MakefilePackage):

--- a/packages/log4cpp/package.py
+++ b/packages/log4cpp/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class Log4cpp(AutotoolsPackage):

--- a/packages/marley/package.py
+++ b/packages/marley/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class Marley(Package):

--- a/packages/nucondb/package.py
+++ b/packages/nucondb/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class Nucondb(MakefilePackage):

--- a/packages/pandora/package.py
+++ b/packages/pandora/package.py
@@ -7,6 +7,7 @@ import glob
 import os.path
 
 from spack import *
+from spack.package import *
 
 
 class Pandora(CMakePackage):

--- a/packages/pdfsets/package.py
+++ b/packages/pdfsets/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class Pdfsets(Package):

--- a/packages/prometheus-cpp/package.py
+++ b/packages/prometheus-cpp/package.py
@@ -21,6 +21,7 @@
 # ----------------------------------------------------------------------------
 
 from spack import *
+from spack.package import *
 
 
 class PrometheusCpp(CMakePackage):

--- a/packages/py-dash/package.py
+++ b/packages/py-dash/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class PyDash(PythonPackage):

--- a/packages/py-geventhttpclient/package.py
+++ b/packages/py-geventhttpclient/package.py
@@ -21,6 +21,7 @@
 # ----------------------------------------------------------------------------
 
 from spack import *
+from spack.package import *
 
 
 class PyGeventhttpclient(PythonPackage):

--- a/packages/py-grpcio-tools/package.py
+++ b/packages/py-grpcio-tools/package.py
@@ -3,13 +3,15 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 
 class PyGrpcioTools(PythonPackage):
     """HTTP/2-based RPC framework."""
 
     homepage = "https://grpc.io/"
     url = "https://pypi.io/packages/source/g/grpcio-tools/grpcio-tools-1.35.0.tar.gz"
-    version("1.59.0", sha256="aa4018f2d8662ac4d9830445d3d253a11b3e096e8afe20865547137aa1160e93") 
+    version("1.59.0", sha256="aa4018f2d8662ac4d9830445d3d253a11b3e096e8afe20865547137aa1160e93")
     version("1.58.0", sha256="6f4d80ceb591e31ca4dceec747dbe56132e1392a0a9bb1c8fe001d1b5cac898a")
     version("1.35.0", sha256="9e2a41cba9c5a20ae299d0fdd377fe231434fa04cbfbfb3807293c6ec10b03cf")
 

--- a/packages/py-ipywe/package.py
+++ b/packages/py-ipywe/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class PyIpywe(PythonPackage):

--- a/packages/py-julia/package.py
+++ b/packages/py-julia/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class PyJulia(PythonPackage):

--- a/packages/py-jupyter-full-width/package.py
+++ b/packages/py-jupyter-full-width/package.py
@@ -21,6 +21,7 @@
 # ----------------------------------------------------------------------------
 
 from spack import *
+from spack.package import *
 
 
 class PyJupyterFullWidth(PythonPackage):

--- a/packages/py-jupyterlab-launcher/package.py
+++ b/packages/py-jupyterlab-launcher/package.py
@@ -21,6 +21,7 @@
 # ----------------------------------------------------------------------------
 
 from spack import *
+from spack.package import *
 
 
 class PyJupyterlabLauncher(PythonPackage):

--- a/packages/py-jupyterlab-templates/package.py
+++ b/packages/py-jupyterlab-templates/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class PyJupyterlabTemplates(PythonPackage):

--- a/packages/py-jupyterlab-widgets/package.py
+++ b/packages/py-jupyterlab-widgets/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class PyJupyterlabWidgets(PythonPackage):

--- a/packages/py-matplotlylib/package.py
+++ b/packages/py-matplotlylib/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class PyMatplotlylib(PythonPackage):

--- a/packages/py-plotly-scientific-plots/package.py
+++ b/packages/py-plotly-scientific-plots/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class PyPlotlyScientificPlots(PythonPackage):

--- a/packages/py-pygccxml/package.py
+++ b/packages/py-pygccxml/package.py
@@ -21,6 +21,7 @@
 # ----------------------------------------------------------------------------
 
 from spack import *
+from spack.package import *
 
 
 class PyPygccxml(PythonPackage):

--- a/packages/py-pyinotify/package.py
+++ b/packages/py-pyinotify/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class PyPyinotify(PythonPackage):

--- a/packages/py-rplotmaker/package.py
+++ b/packages/py-rplotmaker/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.package import *
 
 
 class PyRplotmaker(PythonPackage):

--- a/packages/py-srproxy/package.py
+++ b/packages/py-srproxy/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class PySrproxy(Package):

--- a/packages/sbnanaobj/package.py
+++ b/packages/sbnanaobj/package.py
@@ -21,6 +21,7 @@
 # ----------------------------------------------------------------------------
 
 from spack import *
+from spack.package import *
 
 
 class Sbnanaobj(CMakePackage):

--- a/packages/sbncode/package.py
+++ b/packages/sbncode/package.py
@@ -7,6 +7,7 @@ import os
 
 import spack.util.spack_json as sjson
 from spack import *
+from spack.package import *
 
 
 def sanitize_environments(*args):

--- a/packages/sbndaq-artdaq-core/package.py
+++ b/packages/sbndaq-artdaq-core/package.py
@@ -5,6 +5,7 @@
 
 import spack.util.spack_json as sjson
 from spack import *
+from spack.package import *
 
 
 class SbndaqArtdaqCore(CMakePackage):

--- a/packages/sbndcode/package.py
+++ b/packages/sbndcode/package.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 from spack import *
+from spack.package import *
 
 libdir = "%s/var/spack/repos/fnal_art/lib" % os.environ["SPACK_ROOT"]
 if libdir not in sys.path:

--- a/packages/sbnobj/package.py
+++ b/packages/sbnobj/package.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 from spack import *
+from spack.package import *
 
 libdir = "%s/var/spack/repos/fnal_art/lib" % os.environ["SPACK_ROOT"]
 if libdir not in sys.path:

--- a/packages/stan-math/package.py
+++ b/packages/stan-math/package.py
@@ -23,6 +23,7 @@
 import os
 
 from spack import *
+from spack.package import *
 
 
 class StanMath(Package):

--- a/packages/stan/package.py
+++ b/packages/stan/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 class Stan(Package):

--- a/packages/tensorflow/package.py
+++ b/packages/tensorflow/package.py
@@ -6,6 +6,7 @@
 import os
 
 from spack import *
+from spack.package import *
 
 
 class Tensorflow(Package):

--- a/packages/wirecell/package.py
+++ b/packages/wirecell/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.package import *
 
 
 def sanitize_environments(*args):


### PR DESCRIPTION
Spack is pickier than it used to be.  This PR includes the import statements necessary for providing package base classes.