### PR TITLE
fix error for alpha3 release:

### DIFF
--- a/packages/muse-externals/package.py
+++ b/packages/muse-externals/package.py
@@ -133,8 +133,8 @@ class MuseExternals(BundlePackage):
         depends_on("trace@v3_17_09", type=("build", "run"))
         depends_on("vecgeom", type=("build", "run"))
         depends_on("xerces-c@3.2.3", type=("build", "run"))
-        depends_on("fftw-api", type=("build", "run"))
-        depends_on("fftw", type=("build", "run"))
+        depends_on("fftw-api", type=("build", "run"), when="@p041")
+        depends_on("fftw", type=("build", "run"), when="@p041")
 
     def setup_run_environment(self, env):
 

--- a/packages/muse-externals/package.py
+++ b/packages/muse-externals/package.py
@@ -133,7 +133,8 @@ class MuseExternals(BundlePackage):
         depends_on("trace@v3_17_09", type=("build", "run"))
         depends_on("vecgeom", type=("build", "run"))
         depends_on("xerces-c@3.2.3", type=("build", "run"))
-        depends_on("fftw-api ^fftw")
+        depends_on("fftw-api", type=("build", "run"))
+        depends_on("fftw", type=("build", "run"))
 
     def setup_run_environment(self, env):
 

--- a/packages/muse-externals/package.py
+++ b/packages/muse-externals/package.py
@@ -133,7 +133,6 @@ class MuseExternals(BundlePackage):
         depends_on("trace@v3_17_09", type=("build", "run"))
         depends_on("vecgeom", type=("build", "run"))
         depends_on("xerces-c@3.2.3", type=("build", "run"))
-        depends_on("fftw-api", type=("build", "run"))
         depends_on("fftw", type=("build", "run"))
 
     def setup_run_environment(self, env):

--- a/packages/muse-externals/package.py
+++ b/packages/muse-externals/package.py
@@ -133,7 +133,6 @@ class MuseExternals(BundlePackage):
         depends_on("trace@v3_17_09", type=("build", "run"))
         depends_on("vecgeom", type=("build", "run"))
         depends_on("xerces-c@3.2.3", type=("build", "run"))
-        depends_on("fftw", type=("build", "run"))
 
     def setup_run_environment(self, env):
 

--- a/packages/muse-externals/package.py
+++ b/packages/muse-externals/package.py
@@ -133,8 +133,8 @@ class MuseExternals(BundlePackage):
         depends_on("trace@v3_17_09", type=("build", "run"))
         depends_on("vecgeom", type=("build", "run"))
         depends_on("xerces-c@3.2.3", type=("build", "run"))
-        depends_on("fftw-api", type=("build", "run"), when="@p041")
-        depends_on("fftw", type=("build", "run"), when="@p041")
+        depends_on("fftw-api", type=("build", "run"))
+        depends_on("fftw", type=("build", "run"))
 
     def setup_run_environment(self, env):
 


### PR DESCRIPTION

Our current recipe for muse-externals has a depends_on clause that 1.0 alph3 doesn't like:

==> Error: cannot load package muse-externals from the fnal_art repository: the ^ sigil cannot be used in depends_on directives. Please reformulate the directive below as multiple directives:

	depends_on("fftw-api ^fftw", when="@p041")