### PR TITLE
remove `url_for_version` from nucondb recipe

### DIFF
--- a/packages/nucondb/package.py
+++ b/packages/nucondb/package.py
@@ -49,10 +49,6 @@ class Nucondb(MakefilePackage):
             r"catch \(WebAPIException we\)", "catch (WebAPIException &we)", "src/nucondb.cc"
         )
 
-    def url_for_version(self, version):
-        url = "https://cdcvs.fnal.gov/cgi-bin/git_archive.cgi/cvs/projects/{0}.v{1}.tbz2"
-        return url.format("ifdhc-" + self.name, version.underscored)
-
     @property
     def build_targets(self):
         cxxstd = self.spec.variants["cxxstd"].value


### PR DESCRIPTION
the nucondb package URL was updated to github in #107, but `url_for_version` still pointed to cdcvs which led to errors in checksum comparison. this PR removes `url_for_version` so the recipe instead defaults to using spack's inbuilt mechanism to automatically infer the package URL for a given version. cc @marcmengel