### PR TITLE
Fix "c" constraint due to removed version

### DIFF
--- a/spack_repo/fnal_art/packages/fhicl_cpp/package.py
+++ b/spack_repo/fnal_art/packages/fhicl_cpp/package.py
@@ -35,7 +35,7 @@ class FhiclCpp(CMakePackage, FnalGithubPackage):
     conflicts("cxxstd=17", when="@4.19.00:")
 
     depends_on("cxx", type="build")
-    depends_on("c", when="@:4.19.01", type="build")
+    depends_on("c", when="@:4.19.02", type="build")
     depends_on("boost@:1.82", when="@:4.19")
     depends_on("boost+program_options+test")
     depends_on("cetlib")


### PR DESCRIPTION
`fhicl-cpp` version 4.19.01 was removed in favor of 4.19.02.  This PR updates the `depends_on("c", ...)` constraint accordingly.