### PR TITLE
Enable `xrootd` variant for root

### DIFF
--- a/spack_repo/fnal_art/packages/art_root_io/package.py
+++ b/spack_repo/fnal_art/packages/art_root_io/package.py
@@ -54,7 +54,7 @@ class ArtRootIo(CMakePackage, FnalGithubPackage):
     depends_on("fhicl-cpp")
     depends_on("hep-concurrency")
     depends_on("messagefacility")
-    depends_on("root+python")
+    depends_on("root+python+xrootd")
     depends_on("sqlite@3.8.2:")
 
     if "SPACK_CMAKE_GENERATOR" in os.environ:


### PR DESCRIPTION
All of the experiments use XRootD, so this PR enables the `xrootd` variant for the `root` package.