### PR TITLE
add support for nusystematics v2

### DIFF
--- a/spack_repo/fnal_art/packages/nuhepmc_cmake_modules/package.py
+++ b/spack_repo/fnal_art/packages/nuhepmc_cmake_modules/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack.package import *
+
+
+class NuhepmcCmakeModules(CMakePackage):
+    """CMake Modules for neutrino event generator tools."""
+
+    homepage = "https://github.com/NuHepMC/CMakeModules"
+    url = "https://github.com/NuHepMC/CMakeModules/archive/v0.2.5.tar.gz"
+
+    license("UNKNOWN")
+
+    version("0.2.5", sha256="8ecc2eeae1fb25779736b57ff5d660e8cd747b038d91b4433bedf58d36ee7673")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("cmake", type="build")
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set("NuHepMCModules_ROOT", self.spec.prefix.cmake)

--- a/spack_repo/fnal_art/packages/nusystematics/package.py
+++ b/spack_repo/fnal_art/packages/nusystematics/package.py
@@ -3,41 +3,24 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install nusystematics
-#
-# You can edit this file again by typing:
-#
-#     spack edit nusystematics
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack.package import *
 
 
 class Nusystematics(CMakePackage):
-    """FIXME: Put a proper description of your package here."""
+    """Neutrino interaction systematics for GENIE3 events."""
 
-    # FIXME: Add a proper url for your package's homepage here.
-    homepage = "https://www.example.com"
-    url = "https://github.com/LArSoft/nusystematics/archive/refs/tags/1.05.07.tar.gz"
-    # FIXME: Add a list of GitHub accounts to
-    # notify when the package is updated.
-    # maintainers("github_user1", "github_user2")
+    homepage = "https://github.com/NuSystematics/nusystematics"
+    url = "https://github.com/LArSoft/nusystematics/archive/v1_05_07.tar.gz"
 
-    # FIXME: Add the SPDX identifier of the project's license below.
-    # See https://spdx.org/licenses/ for a list.
+    def url_for_version(self, version):
+        org = "NuSystematics" if version[0] >= 2 else "LArSoft"
+        return f"https://github.com/{org}/nusystematics/archive/v{version.underscored}.tar.gz"
+
     license("UNKNOWN")
-    
+
+    version("02.00.05", sha256="89cad28d6f01b248e2a9b255d4b6256de5b8cf31937c3a105a311589784c58aa")
+    version("1.06.02", sha256="13b306cef60fad91ca35bde40fdefbcb55411804864caa1b9812ec1cdffb50cc")
     version("1.05.07", sha256="69ac5967847c0c20fca98c3ef347dd1eeed4cc7c9f5f897dcb76f7c471d6051b")
 
     depends_on("c", type="build")
@@ -48,6 +31,17 @@ class Nusystematics(CMakePackage):
     depends_on("nufinder")
     depends_on("cetmodules", type="build")
     depends_on("cmake", type="build")
+    depends_on("nuhepmc-cmake-modules", type="build")
+
+    with when("@=02.00.05"):
+        depends_on("systematicstools @02.00.03")
+
+    def setup_build_environment(self, env):
+        env.set("CPM_LOCAL_PACKAGES_ONLY", "1")
+        env.set("PYTHIA6_LIB_DIR", self.spec["pythia6"].prefix.lib)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set("PYTHIA6_LIB_DIR", self.spec["pythia6"].prefix.lib)
 
     def cmake_args(self):
         args = []

--- a/spack_repo/fnal_art/packages/systematicstools/package.py
+++ b/spack_repo/fnal_art/packages/systematicstools/package.py
@@ -10,15 +10,14 @@ from spack.package import *
 class Systematicstools(CMakePackage):
     """Framework for writing, using and interpreting experimental systematic uncertainties."""
 
-    homepage = "https://github.com/LArSoft/systematicstools"
+    homepage = "https://github.com/NuSystematics/systematicstools"
     url = "https://github.com/LArSoft/systematicstools/archive/v01_04_02.tar.gz"
 
     def url_for_version(self, version):
-        return f"https://github.com/LArSoft/systematicstools/archive/v{version.underscored}.tar.gz"
+        org = "NuSystematics" if version[0] >= 2 else "LArSoft"
+        return f"https://github.com/{org}/systematicstools/archive/v{version.underscored}.tar.gz"
 
-    # FIXME: Add a list of GitHub accounts to
-    # notify when the package is updated.
-    # maintainers("github_user1", "github_user2")
+    version("02.00.03", sha256="c323bcd68d931df56d5fda97c5777277de3bfb5451de7c090207053a87ff6a53")
     version("01.04.04", sha256="7436341f63ea205d8b901b75859a26ec81f29fd272bf324c7bdcde713a3b937c")
     version("01.04.02", sha256="0e14b9736b31b7911307e8703d0f386f2a1fb5c1dcaa69a8d7ce9916afb974cd")
 
@@ -40,6 +39,9 @@ class Systematicstools(CMakePackage):
     depends_on("cetmodules", type="build")
 
     depends_on("art-root-io")
+
+    def setup_build_environment(self, env):
+        env.set("CPM_LOCAL_PACKAGES_ONLY", "1")
 
     def cmake_args(self):
         return [


### PR DESCRIPTION
add support for the v2 series of the `nusystematics` package, which is version controlled under the `NuSystematics` organization on github instead of the `LArSoft` organization.