### PR TITLE
update nusystematics checksum

### DIFF
--- a/spack_repo/fnal_art/packages/nusystematics/package.py
+++ b/spack_repo/fnal_art/packages/nusystematics/package.py
@@ -21,7 +21,7 @@ class Nusystematics(CMakePackage):
 
     version("02.00.05", sha256="89cad28d6f01b248e2a9b255d4b6256de5b8cf31937c3a105a311589784c58aa")
     version("1.06.02", sha256="13b306cef60fad91ca35bde40fdefbcb55411804864caa1b9812ec1cdffb50cc")
-    version("1.05.07", sha256="69ac5967847c0c20fca98c3ef347dd1eeed4cc7c9f5f897dcb76f7c471d6051b")
+    version("1.05.07", sha256="8d273475c43cd42cb62f5a66f6fd6bcd90c6ad3cb9b8592c0ca24982356a2db5")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")


### PR DESCRIPTION
in https://github.com/FNALssi/fnal_art/pull/139 the `nusystematics` package recipe switched to use a different tag convention (`v1_05_07` instead of `1.05.07`). these two tags point to the same commit, but the checksum for the tarball is different for this particular package version. this PR updates the package recipe so the tarball checksum corresponds to the tag we're now pulling from the github repository.