### PR TITLE
Correctly prepend ifdhc_config's bin to PATH in dependent run env (ifdhc)

### DIFF
--- a/spack_repo/fnal_art/packages/ifdhc/package.py
+++ b/spack_repo/fnal_art/packages/ifdhc/package.py
@@ -119,8 +119,6 @@ class Ifdhc(MakefilePackage):
         run_env.prepend_path("PATH", self.spec.prefix.bin)
         run_env.prepend_path("PYTHONPATH", self.spec.prefix.lib.python)
         run_env.set("IFDHC_DIR", self.spec.prefix)
-        # put ifdhc_config bin path ahead of us that we saved in os.environ...
-        run_env.prepend_path("PATH", os.environ.get("IFDHC_CONFIG_BIN",""))
 
     def setup_dependent_build_environment(self, spack_env, dspec):
         spack_env.prepend_path("PATH", self.spec.prefix.bin)

--- a/spack_repo/fnal_art/packages/ifdhc_config/package.py
+++ b/spack_repo/fnal_art/packages/ifdhc_config/package.py
@@ -62,5 +62,7 @@ class IfdhcConfig(Package):
     def setup_run_environment(self, run_env):
         run_env.prepend_path("PATH", self.spec.prefix.bin)
         run_env.set("IFDHC_CONFIG_DIR", self.spec.prefix)
-        # save for ifhdc setup_run_environment to use..
-        os.environ["IFDHC_CONFIG_BIN"] = str(self.spec.prefix.bin)
+        run_env.set("IFDHC_CONFIG_BIN", str(self.spec.prefix.bin))
+
+    def setup_dependent_run_environment(self, env, dependent_spect):
+        env.prepend_path("PATH", str(self.spec.prefix.bin))


### PR DESCRIPTION
This prevents issues when using environment modules (ifdhc is set up first, and PATH doesn't get set correctly). 




