### PR TITLE
Remove references spack.llnl.util as spack 1.3.0dev has made them go away

### DIFF
--- a/spack_repo/fnal_art/packages/critic/package.py
+++ b/spack_repo/fnal_art/packages/critic/package.py
@@ -5,7 +5,7 @@
 
 import os
 
-import spack.llnl.util.tty as tty
+import spack.util.tty as tty
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack.package import *

--- a/spack_repo/fnal_art/packages/critic/package.py
+++ b/spack_repo/fnal_art/packages/critic/package.py
@@ -5,7 +5,10 @@
 
 import os
 
-import spack.util.tty as tty
+try:
+    import spack.llnl.util.tty as tty
+else:
+    import spack.util.tty as tty
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack.package import *

--- a/spack_repo/fnal_art/packages/critic/package.py
+++ b/spack_repo/fnal_art/packages/critic/package.py
@@ -7,7 +7,7 @@ import os
 
 try:
     import spack.llnl.util.tty as tty
-else:
+except ImportError:
     import spack.util.tty as tty
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage

--- a/spack_repo/fnal_art/packages/fnal_github_package/package.py
+++ b/spack_repo/fnal_art/packages/fnal_github_package/package.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 try:
     import spack.llnl.util.tty as tty
-else:
+except ImportError:
     import spack.util.tty as tty
 
 import spack.util.spack_json as sjson

--- a/spack_repo/fnal_art/packages/fnal_github_package/package.py
+++ b/spack_repo/fnal_art/packages/fnal_github_package/package.py
@@ -9,7 +9,7 @@ import re
 from functools import wraps
 from pathlib import Path
 
-import spack.llnl.util.tty as tty
+import spack.util.tty as tty
 
 import spack.util.spack_json as sjson
 import spack.util.web

--- a/spack_repo/fnal_art/packages/fnal_github_package/package.py
+++ b/spack_repo/fnal_art/packages/fnal_github_package/package.py
@@ -9,7 +9,10 @@ import re
 from functools import wraps
 from pathlib import Path
 
-import spack.util.tty as tty
+try:
+    import spack.llnl.util.tty as tty
+else:
+    import spack.util.tty as tty
 
 import spack.util.spack_json as sjson
 import spack.util.web

--- a/spack_repo/fnal_art/packages/genie/package.py
+++ b/spack_repo/fnal_art/packages/genie/package.py
@@ -6,8 +6,6 @@
 import inspect
 import os
 
-from spack.llnl.util import filesystem
-
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack.package import *
 

--- a/spack_repo/fnal_art/packages/ifdhc/package.py
+++ b/spack_repo/fnal_art/packages/ifdhc/package.py
@@ -5,7 +5,7 @@
 
 import os
 
-import spack.llnl.util.tty as tty
+import spack.util.tty as tty
 
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 from spack.package import *

--- a/spack_repo/fnal_art/packages/ifdhc/package.py
+++ b/spack_repo/fnal_art/packages/ifdhc/package.py
@@ -7,7 +7,7 @@ import os
 
 try:
     import spack.llnl.util.tty as tty
-else:
+except ImportError:
     import spack.util.tty as tty
 
 from spack_repo.builtin.build_systems.makefile import MakefilePackage

--- a/spack_repo/fnal_art/packages/ifdhc/package.py
+++ b/spack_repo/fnal_art/packages/ifdhc/package.py
@@ -5,7 +5,10 @@
 
 import os
 
-import spack.util.tty as tty
+try:
+    import spack.llnl.util.tty as tty
+else:
+    import spack.util.tty as tty
 
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 from spack.package import *

--- a/spack_repo/fnal_art/packages/ifdhc_config/package.py
+++ b/spack_repo/fnal_art/packages/ifdhc_config/package.py
@@ -5,8 +5,11 @@
 
 import os
 
-import spack.util.tty as tty
-
+try:
+    import spack.llnl.util.tty as tty
+else:
+    import spack.util.tty as tty
+    
 from spack_repo.builtin.build_systems.generic import Package
 from spack.package import *
 

--- a/spack_repo/fnal_art/packages/ifdhc_config/package.py
+++ b/spack_repo/fnal_art/packages/ifdhc_config/package.py
@@ -5,7 +5,7 @@
 
 import os
 
-import spack.llnl.util.tty as tty
+import spack.util.tty as tty
 
 from spack_repo.builtin.build_systems.generic import Package
 from spack.package import *

--- a/spack_repo/fnal_art/packages/ifdhc_config/package.py
+++ b/spack_repo/fnal_art/packages/ifdhc_config/package.py
@@ -7,7 +7,7 @@ import os
 
 try:
     import spack.llnl.util.tty as tty
-else:
+except ImportError:
     import spack.util.tty as tty
     
 from spack_repo.builtin.build_systems.generic import Package


### PR DESCRIPTION
In the process of testing the Phlex 0.3.0 build with the head of Spack's develop branch, some evolution of Spack has broken our recipes.

https://github.com/spack/spack/issues/4021

describes a desire to move filesystem from spack.llnl.util to spack.util, though googling it seems to indicate that removing the import works as well and that tests fine.

https://github.com/spack/spack/pull/52513

moves tty from spack.llnl.util to spack.util and was merged July 7, 2026.  The version of Spack I got when running with the head of develop is 1.3.0dev0, so these changes will be needed going forwards.  I will test them with 1.2.0 and report later in this conversation.